### PR TITLE
[fix] fix handler success metric

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -81,7 +81,7 @@ var HandlerPanicCounts = mustRegister(prometheus.NewCounterVec(
 	[]string{"handler_name", "topic"},
 ))
 
-var HandlerCounts = mustRegister(prometheus.NewCounterVec(
+var HandlerSuccessCounts = mustRegister(prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: prefix + "handler_success",
 		Help: "Number handler success (by handler name and topic)",


### PR DESCRIPTION
The handler success metric was counting invocations, not success. 
Also: renamed the metric in Go which is not backwards compatible.