### PR TITLE
[fix] list topics before trying to create them (BREAKING CHANGE)

### DIFF
--- a/.github/workflows/pg.yml
+++ b/.github/workflows/pg.yml
@@ -89,31 +89,28 @@ jobs:
       - name: Build
         run: go build -v ./...
 
-      - name: Test
+      - name: Test and Coverage
         env:
           EVENTS_POSTGRES_TEST_DSN: "postgres://postgres:postgres@localhost?sslmode=disable"
           EVENTS_KAFKA_BROKERS: "localhost:9092"
-          EVENTS_DEBUG_NOTIFY: "true"
-          EVENTS_DEBUG_PRODUCE: "true"
-          EVENTS_DEBUG_DELIVERY: "true"
-          EVENTS_DEBUG_ACK: "true"
-          EVENTS_DEBUG_CONSUME: "true"
-          EVENTS_DEBUG_START_CONSUME: "true"
-          EVENTS_DEBUG_BATCHING: "true"
-        run: go test ./eventpg/... -v
-
-      - name: Run Coverage
-        env:
-          EVENTS_POSTGRES_TEST_DSN: "postgres://postgres:postgres@localhost?sslmode=disable"
-          EVENTS_KAFKA_BROKERS: "localhost:9092"
-          EVENTS_DEBUG_NOTIFY: "true"
-          EVENTS_DEBUG_PRODUCE: "true"
-          EVENTS_DEBUG_DELIVERY: "true"
-          EVENTS_DEBUG_ACK: "true"
-          EVENTS_DEBUG_CONSUME: "true"
-          EVENTS_DEBUG_START_CONSUME: "true"
-          EVENTS_DEBUG_BATCHING: "true"
-        run: go test -coverprofile=coverage.txt -covermode=atomic -coverpkg=github.com/singlestore-labs/events/... ./eventpg/... 
+        run: |
+          export EVENTS_DEBUG_NOTIFY="true"
+          export EVENTS_DEBUG_PRODUCE="true"
+          export EVENTS_DEBUG_DELIVERY="true"
+          export EVENTS_DEBUG_ACK="true"
+          export EVENTS_DEBUG_CONSUME="true"
+          export EVENTS_DEBUG_START_CONSUME="true"
+          export EVENTS_DEBUG_BATCHING="true"
+          go test -coverprofile=coverage2.txt -covermode=atomic -coverpkg=github.com/singlestore-labs/events/... -v ./eventpg/...  
+          export EVENTS_DEBUG_NOTIFY="false"
+          export EVENTS_DEBUG_PRODUCE="false"
+          export EVENTS_DEBUG_DELIVERY="false"
+          export EVENTS_DEBUG_ACK="false"
+          export EVENTS_DEBUG_CONSUME="false"
+          export EVENTS_DEBUG_START_CONSUME="false"
+          export EVENTS_DEBUG_BATCHING="false"
+          go test -coverprofile=coverage1.txt -covermode=atomic -coverpkg=github.com/singlestore-labs/events/... ./eventpg/... 
+          cat coverage1.txt coverage2.txt > coverage.txt
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/s2.yml
+++ b/.github/workflows/s2.yml
@@ -90,31 +90,28 @@ jobs:
       - name: Build
         run: go build -v ./...
 
-      - name: Test
+      - name: Test and Coverage
         env:
           EVENTS_S2TEST_DSN: "root:test@tcp(127.0.0.1:3306)/eventstest?tls=false&parseTime=true"
           EVENTS_KAFKA_BROKERS: "localhost:9092"
-          EVENTS_DEBUG_NOTIFY: "true"
-          EVENTS_DEBUG_PRODUCE: "true"
-          EVENTS_DEBUG_DELIVERY: "true"
-          EVENTS_DEBUG_ACK: "false"
-          EVENTS_DEBUG_CONSUME: "true"
-          EVENTS_DEBUG_START_CONSUME: "true"
-          EVENTS_DEBUG_BATCHING: "true"
-        run: go test ./events2/... -v --parallel 3
-
-      - name: Run Coverage
-        env:
-          EVENTS_S2TEST_DSN: "root:test@tcp(127.0.0.1:3306)/eventstest?tls=false&parseTime=true"
-          EVENTS_KAFKA_BROKERS: "localhost:9092"
-          EVENTS_DEBUG_NOTIFY: "true"
-          EVENTS_DEBUG_PRODUCE: "true"
-          EVENTS_DEBUG_DELIVERY: "true"
-          EVENTS_DEBUG_ACK: "true"
-          EVENTS_DEBUG_CONSUME: "true"
-          EVENTS_DEBUG_START_CONSUME: "true"
-          EVENTS_DEBUG_BATCHING: "true"
-        run: go test -coverprofile=coverage.txt -covermode=atomic -coverpkg=github.com/singlestore-labs/events/... ./events2/... --parallel 3
+        run: |
+          export EVENTS_DEBUG_NOTIFY="true"
+          export EVENTS_DEBUG_PRODUCE="true"
+          export EVENTS_DEBUG_DELIVERY="true"
+          export EVENTS_DEBUG_ACK="true"
+          export EVENTS_DEBUG_CONSUME="true"
+          export EVENTS_DEBUG_START_CONSUME="true"
+          export EVENTS_DEBUG_BATCHING="true"
+          go test -coverprofile=coverage1.txt -covermode=atomic -coverpkg=github.com/singlestore-labs/events/... -v ./events2/... 
+          export EVENTS_DEBUG_NOTIFY="false"
+          export EVENTS_DEBUG_PRODUCE="false"
+          export EVENTS_DEBUG_DELIVERY="false"
+          export EVENTS_DEBUG_ACK="false"
+          export EVENTS_DEBUG_CONSUME="false"
+          export EVENTS_DEBUG_START_CONSUME="false"
+          export EVENTS_DEBUG_BATCHING="false"
+          go test -coverprofile=coverage2.txt -covermode=atomic -coverpkg=github.com/singlestore-labs/events/... ./events2/... 
+          cat coverage1.txt coverage2.txt > coverage.txt
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,0 +1,15 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConstants(t *testing.T) {
+	t.Log("make sure nobody changes contants in ways that would break behavior")
+	assert.Greater(t, broadcastReaderIdleTimeout, time.Second)
+	assert.Less(t, broadcastHeartbeatRandom, 0.8)
+	assert.Less(t, maxConsumerGroupNameLength, 36)
+}

--- a/dead_letter.go
+++ b/dead_letter.go
@@ -53,7 +53,15 @@ func (lib *Library[ID, TX, DB]) startDeadLetterConsumers(ctx context.Context, co
 	if len(preCreate) == 0 {
 		return
 	}
-	lib.precreateTopicsForConsuming(ctx, consumerGroup, preCreate)
+	// This shouldn't error because the precreate for the non-dead letter versions
+	// succeeded before this was called
+	err := lib.precreateTopicsForConsuming(ctx, consumerGroup, preCreate)
+	if err != nil {
+		if e := ctx.Err(); e == nil {
+			lib.tracer.Logf("[events] UNEXPECTED ERROR creating topics for dead letter consumption, not consuming dead letter topics: %+v", err)
+		}
+		return
+	}
 	var startConsumer bool
 	dlGroup := &group{
 		topics:  make(map[string]*topicHandlers),

--- a/eventdb/support.go
+++ b/eventdb/support.go
@@ -1,0 +1,15 @@
+package eventdb
+
+import "github.com/singlestore-labs/events/eventmodels"
+
+func PreAllocateIDMap[T any](events ...eventmodels.ProducingEvent) map[string][]T {
+	ids := make(map[string][]T)
+	counts := make(map[string]int)
+	for _, event := range events {
+		counts[event.GetTopic()]++
+	}
+	for topic, count := range counts {
+		ids[topic] = make([]T, 0, count)
+	}
+	return ids
+}

--- a/eventmodels/interfaces.go
+++ b/eventmodels/interfaces.go
@@ -52,11 +52,12 @@ type Producer[ID AbstractID[ID], TX AbstractTX] interface {
 	Produce(context.Context, ProduceMethod, ...ProducingEvent) error
 	// ProduceFromTable should be called by transaction wappers. It will
 	// send ids to a central thread that will in turn call ProduceSpecificTxEvents.
-	ProduceFromTable(ctx context.Context, eventIDs []ID) error
+	ProduceFromTable(ctx context.Context, eventIDs map[string][]ID) error
 	RecordError(string, error) error       // pauses to avoid spamming
 	RecordErrorNoWait(string, error) error // does not pause
 	IsConfigured() bool
 	Tracer() Tracer
+	ValidateTopics(context.Context, []string) error
 }
 
 type Tracer interface {

--- a/eventtest/common.go
+++ b/eventtest/common.go
@@ -109,16 +109,17 @@ func GenerateSharedTestMatrix[
 	DB AugmentAbstractDB[ID, TX],
 ]() map[string]nject.Provider {
 	return map[string]nject.Provider{
-		"BatchDelivery":        nject.Provide("BD", BatchDeliveryTest[ID, TX, DB]),
-		"BroadcastDelivery":    nject.Provide("BCD", BroadcastDeliveryTest[ID, TX, DB]),
-		"CloudEventEncoding":   nject.Provide("CEET", CloudEventEncodingTest[ID, TX, DB]),
-		"DeadLetterBlock":      nject.Provide("DLB", DeadLetterBlockTest[ID, TX, DB]),
-		"DeadLetterDiscard":    nject.Provide("DLD", DeadLetterDiscardTest[ID, TX, DB]),
-		"DeadLetterRetryLater": nject.Provide("DLRL", DeadLetterRetryLaterTest[ID, TX, DB]),
-		"DeadLetterSave":       nject.Provide("DLS", DeadLetterSaveTest[ID, TX, DB]),
-		"ErrorWhenMisused":     nject.Provide("EWM", ErrorWhenMisusedTest[ID, TX, DB]),
-		"ExactlyOnceDelivery":  nject.Provide("EOD", ExactlyOnceDeliveryTest[ID, TX, DB]),
-		"IdempotentDelivery":   nject.Provide("ID", IdempotentDeliveryTest[ID, TX, DB]),
-		"Notifier":             nject.Provide("N", EventNotifierTest[ID, TX, DB]),
+		"BatchDelivery":         nject.Provide("BD", BatchDeliveryTest[ID, TX, DB]),
+		"BroadcastDelivery":     nject.Provide("BCD", BroadcastDeliveryTest[ID, TX, DB]),
+		"CloudEventEncoding":    nject.Provide("CEET", CloudEventEncodingTest[ID, TX, DB]),
+		"ComprehensiveNotifier": nject.Provide("N", EventComprehensiveNotifierTest[ID, TX, DB]),
+		"DeadLetterBlock":       nject.Provide("DLB", DeadLetterBlockTest[ID, TX, DB]),
+		"DeadLetterDiscard":     nject.Provide("DLD", DeadLetterDiscardTest[ID, TX, DB]),
+		"DeadLetterRetryLater":  nject.Provide("DLRL", DeadLetterRetryLaterTest[ID, TX, DB]),
+		"DeadLetterSave":        nject.Provide("DLS", DeadLetterSaveTest[ID, TX, DB]),
+		"ErrorWhenMisused":      nject.Provide("EWM", ErrorWhenMisusedTest[ID, TX, DB]),
+		"ExactlyOnceDelivery":   nject.Provide("EOD", ExactlyOnceDeliveryTest[ID, TX, DB]),
+		"IdempotentDelivery":    nject.Provide("ID", IdempotentDeliveryTest[ID, TX, DB]),
+		"UnfilteredNotifier":    nject.Provide("UN", EventUnfilteredNotifierTest[ID, TX, DB]),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/segmentio/kafka-go v0.4.47
 	github.com/sharnoff/eventdistributor v0.1.1
-	github.com/singlestore-labs/generic v0.2.0
+	github.com/singlestore-labs/generic v0.3.0
 	github.com/singlestore-labs/once v0.0.1
 	github.com/singlestore-labs/simultaneous v0.0.1
 	github.com/singlestore-labs/wait v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUan
 github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/sharnoff/eventdistributor v0.1.1 h1:7OOcn2f9w5zGCjHm8KcIYKyp6y+W7xTNvo7rgnhWvvg=
 github.com/sharnoff/eventdistributor v0.1.1/go.mod h1:OEKtalwdvbR4ZSEkNzMUTcu5aSaW+jRHjmamBlyTcqk=
-github.com/singlestore-labs/generic v0.2.0 h1:IOx9/lHiiXEbEO84m62NsEuc6DBuEZS2xKnd1MBlums=
-github.com/singlestore-labs/generic v0.2.0/go.mod h1:EYP3HOfc9BcytHJMwwQsc99fR6EXxCd13B1egFCF3BQ=
+github.com/singlestore-labs/generic v0.3.0 h1:B6BoVcljHfwfzQ/ZcFdSaTTI8eUe+b9ENzcNVcqs0i8=
+github.com/singlestore-labs/generic v0.3.0/go.mod h1:EYP3HOfc9BcytHJMwwQsc99fR6EXxCd13B1egFCF3BQ=
 github.com/singlestore-labs/once v0.0.1 h1:GGfXqAm1+Aywxo2fSNBgMWN+8H/M/VpbbPgVN8Berto=
 github.com/singlestore-labs/once v0.0.1/go.mod h1:2f063S0jPlp6Qll5WdwwXIJ6I3OJYdTZtlUQ5zBvrJQ=
 github.com/singlestore-labs/simultaneous v0.0.1 h1:bg+zTtvXRqo2FoI3XK+dhbO7wwtiEJdVuJZ6rsaJYoM=


### PR DESCRIPTION
The big change is that even when events are produced asynchronously, the topics in the events will be validated synchronously. When pre-registration is required and the topic is not pre-registered, then this can cause a transaction delay to check if the topic already exists. This delay will only happen once since we won't re-check.

- change APIs to pass around `map[topicName][]eventID` instead of `[]eventID` while producing events inside transactions
- validate topics synchronously during transaction produce even if the events are produced asynchonously
- List topics before attempting to create them
  There is test flakiness around topic creation when creating multiple topics at once. One way to address it is to try to create fewer topics at once by properly detecting which ones already exist
- Try all brokers when trying to find the controller
  When connecting to the controller the old code only tried the first broker. If that was down, we could fail to find the controller. 
- A new exported error: `UnregisteredTopicError` for when a topic needs to be pre-registered but isn't.
- Fixed an edge case error -- trying to create a topic that should have been pre-registered could cause other topic creation requests to time out. Instead, they should error immediately
- Only start the broadcast heartbeat sender after the broadcast listener is live (prevents lots of broadcast heartbeat traffic)
- Pre-create all topics for consumption before starting any consumers
- moved metric initialization so that it's only called once
- When restarting broadcast readers, don't reset the read position
- Consumer startup that includes broadcast consumers, now waits until at least one broadcast message has been recevied

This is a breaking change because:

- the `ProduceFromTable` method in the `eventmodels.Producer` interface changed
- `eventsdb.SaveEventsFunc` has a new API
- `SaveEventsInsideTx` in `events2` and `eventspg` have new APIs
- `ProduceFromTable` has a new API
- `eventmodels.Producer` now includes `ValidateTopics`
- the API for `WrapTransaction` has changed

The changes are small but breaking