### PR TITLE
[feat] refresh broadcast readers on reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,18 @@ features are not available:
 
 For production use, configure:
 
-- at least 3 availablity zones (replicas);
-- `min.insync.replicas` to be at least 2;
-- `replication.factor` to be at least one more than `min.insync.replicas` and equal to your number of replicas.
+At least 3 availability zones (replicas) and each topic needs:
 
+- `min.insync.replicas`: at least 2 and less than the number of availability zones
+- `replication.factor`: the number of availabilty zones 
+
+Because broadcast topics sometimes use the `offsetsForTimes` request, message timestamps must be
+set to the the non-default value of `LogAppendTime`. This is the default for topics created by
+the events library. See [discusstion with ChatGPT](https://chatgpt.com/share/68432d60-ac28-8005-bea1-cf3c175204ba)
+about why this is important.
+
+- `message.timestamp.type`: `LogAppendTime`
+
+Since the message timestamps will use the log append time, if message consumers want to know when
+the message was created, a second timestamp needs to be within the message itself. Perhaps as
+a header.

--- a/dead_letter.go
+++ b/dead_letter.go
@@ -106,7 +106,7 @@ func (lib *Library[ID, TX, DB]) startDeadLetterConsumers(ctx context.Context, co
 		if debugConsumeStartup {
 			lib.tracer.Logf("[events] Debug: consume startwait +1 for %s", consumerGroup+deadLetterGroupPostfix)
 		}
-		go lib.startConsumingGroup(ctx, consumerGroup+deadLetterGroupPostfix, dlGroup, limiter, false, allStarted, allDone, true)
+		go lib.startConsumingGroup(ctx, consumerGroup+deadLetterGroupPostfix, dlGroup, limiter, false, allStarted, allDone, true, nil, nil, nil)
 	}
 }
 

--- a/topics.go
+++ b/topics.go
@@ -313,6 +313,13 @@ func (lib *LibraryNoDB) CreateTopics(ctx context.Context, why string, topics []s
 				}
 				tc.ConfigEntries = setIntConfigValue(tc, "min.insync.replicas", mir)
 			}
+			tsti := generic.FirstMatchIndex(tc.ConfigEntries, func(e kafka.ConfigEntry) bool { return e.ConfigName == "message.timestamp.type" })
+			if tsti < 0 {
+				tc.ConfigEntries = append(tc.ConfigEntries, kafka.ConfigEntry{
+					ConfigName:  "message.timestamp.type",
+					ConfigValue: "LogAppendTime",
+				})
+			}
 
 			mir = getIntConfigValue(tc, "min.insync.replicas")
 			var ctr kafka.CreateTopicsRequest


### PR DESCRIPTION
This is part2 of adding support for using events w/o a database. Here we further refactor broadcast consumers so that when they're re-created, they are still guaranteed to be exclusive.

One side effect of this work is that topics are created with  `message.timestamp.type`: `LogAppendTime`

This is on top of #28, followed by #30