### PR TITLE
[chore] bump go to 1.24

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Run coverage
         run: make calculate_coverage

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x, 1.25.x]
+        go-version: [1.24.x, 1.25.x, 1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/nodb.yml
+++ b/.github/workflows/nodb.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/pg.yml
+++ b/.github/workflows/pg.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/s2.yml
+++ b/.github/workflows/s2.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Get Go cache paths
         id: go-cache-paths

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/singlestore-labs/events
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/Masterminds/squirrel v1.5.4


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to a Go toolchain upgrade, which can introduce compile/test failures or subtle behavior changes across CI and local builds.
> 
> **Overview**
> Updates the project’s Go toolchain baseline to **Go 1.24** by bumping `go.mod` from `go 1.23.0` to `go 1.24.0`.
> 
> Aligns CI to the new baseline by switching multiple GitHub Actions workflows to install Go `1.24` (coverage/integration jobs) and updating the unit-test matrix to drop `1.23.x` and add `1.26.x`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af6757f832c3a84cbc99c63dbca11b7bd0835ffe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->