### PR TITLE
Add delay to topic listing retries

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -122,6 +122,7 @@ type LibraryNoDB struct {
 	topicsWork                pwork.Work[string, topicsWhy] // un-prefixed in APIs
 	topicListingStarted       sync.Once
 	topicsHaveBeenListed      chan struct{}
+	topicsListingErr          error
 	mustRegisterTopics        bool
 	hasTxConsumers            bool
 	clientID                  string

--- a/connection.go
+++ b/connection.go
@@ -120,8 +120,7 @@ type LibraryNoDB struct {
 	ready                     atomic.Int32
 	topicConfig               map[string]kafka.TopicConfig  // un-prefixed
 	topicsWork                pwork.Work[string, topicsWhy] // un-prefixed in APIs
-	topicListingLock          sync.Mutex
-	topicListingAttemptDone   chan struct{}
+	topicListingStarted       sync.Once
 	topicsHaveBeenListed      chan struct{}
 	mustRegisterTopics        bool
 	hasTxConsumers            bool

--- a/connection.go
+++ b/connection.go
@@ -461,7 +461,7 @@ func (lib *Library[ID, TX, DB]) start(ctx context.Context, str string, args ...a
 // If StartConsuming or CatchUpProduce have been called, cancel their contexts
 // before calling Shutdown. Shutdown does not cancel those contexts.
 //
-// If StartConsuming and CatchUpProduce were never called, Shutdown should still
+// If StartConsuming and CatchUpProduce were never called, Shutdown should
 // be called to terminate library-owned background threads.
 func (lib *LibraryNoDB) Shutdown(ctx context.Context) {
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, map[string]string{

--- a/connection.go
+++ b/connection.go
@@ -956,7 +956,7 @@ func (lib *LibraryNoDB) logf(ctx context.Context, format string, a ...any) {
 //   - when Shutdown is called before any library lifecycle contexts are registered
 //
 // The returned context has a span. It is cancelled when the returned done is called.
-func (lib *LibraryNoDB) threadContext(_ context.Context, spanMap map[string]string) (context.Context, func()) {
+func (lib *LibraryNoDB) threadContext(spanMap map[string]string) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
 	lib.libraryDone.Add(1)

--- a/connection.go
+++ b/connection.go
@@ -962,7 +962,7 @@ func (lib *LibraryNoDB) logf(ctx context.Context, format string, a ...any) {
 func (lib *LibraryNoDB) threadContext(spanMap map[string]string) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
-	lib.libraryDone.Add(1)
+	lib.libraryDone.Add(2)
 	go func() {
 		defer lib.libraryDone.Done()
 		defer cancel()
@@ -1000,8 +1000,9 @@ func (lib *LibraryNoDB) threadContext(spanMap map[string]string) (context.Contex
 	// We don't call spanDone in the goroutine. Wait for the returned done
 	// function so the caller controls the span lifetime.
 	return ctx, func() {
+		defer lib.libraryDone.Done()
+		defer spanDone()
 		cancel()
-		spanDone()
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -120,7 +120,7 @@ type LibraryNoDB struct {
 	ready                     atomic.Int32
 	topicConfig               map[string]kafka.TopicConfig  // un-prefixed
 	topicsWork                pwork.Work[string, topicsWhy] // un-prefixed in APIs
-	topicListingStarted       sync.Once
+	topicListingLock          sync.Mutex
 	topicsHaveBeenListed      chan struct{}
 	mustRegisterTopics        bool
 	hasTxConsumers            bool

--- a/connection.go
+++ b/connection.go
@@ -457,8 +457,11 @@ func (lib *Library[ID, TX, DB]) start(ctx context.Context, str string, args ...a
 }
 
 // Shutdown returns when the library is completely shut down.
-// Shutdown cancels library-owned background threads. It does not cancel
-// the consume or catch-up-producer contexts.
+// If StartConsuming or CatchUpProduce have been called, cancel their contexts
+// before calling Shutdown. Shutdown does not cancel those contexts.
+//
+// If StartConsuming and CatchUpProduce were never called, Shutdown should still
+// be called to terminate library-owned background threads.
 func (lib *LibraryNoDB) Shutdown(ctx context.Context) {
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, map[string]string{
 		"action": "wait for shutdown",

--- a/connection.go
+++ b/connection.go
@@ -968,7 +968,7 @@ var gateEventsThreadContextLifecycle = codegate.New("EventsThreadContextLifecycl
 // The returned context has a span. It is cancelled when the returned done is called.
 func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
 	if !gateEventsThreadContextLifecycle.Enabled() {
-		return lib.threadContextSnapshot(backupCtx, spanMap)
+		return lib.threadContextOld(backupCtx, spanMap)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
@@ -1016,7 +1016,7 @@ func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[str
 	}
 }
 
-func (lib *LibraryNoDB) threadContextSnapshot(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
+func (lib *LibraryNoDB) threadContextOld(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
 	waitFor := make([]context.Context, 0, 2)

--- a/connection.go
+++ b/connection.go
@@ -88,9 +88,6 @@ var (
 	legalConsumerGroupNames = regexp.MustCompile(fmt.Sprintf(`^[-._a-zA-Z0-9]{1,%d}$`, maxConsumerGroupNameLength))
 )
 
-// TODO: remove this code gate once dynamic threadContext lifecycle handling is stable in production.
-var gateEventsThreadContextLifecycle = codegate.New("EventsThreadContextLifecycle")
-
 var instanceCount atomic.Int32
 
 type Library[ID eventmodels.AbstractID[ID], TX eventmodels.AbstractTX, DB eventmodels.AbstractDB[ID, TX]] struct {
@@ -960,6 +957,9 @@ func (lib *LibraryNoDB) logf(ctx context.Context, format string, a ...any) {
 	lib.tracerProvider(ctx)(format, a...)
 }
 
+// TODO: remove this code gate once dynamic threadContext lifecycle handling is stable in production.
+var gateEventsThreadContextLifecycle = codegate.New("EventsThreadContextLifecycle")
+
 // threadContext cancels the returned context at the earlier of:
 //   - when the returned done() func is called
 //   - when all registered consume and catch-up-produce contexts are cancelled
@@ -967,10 +967,10 @@ func (lib *LibraryNoDB) logf(ctx context.Context, format string, a ...any) {
 //
 // The returned context has a span. It is cancelled when the returned done is called.
 func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
-	if !gateEventsThreadContextLifecycle.Enabled() {
-		return lib.threadContextSnapshot(backupCtx, spanMap)
+	if gateEventsThreadContextLifecycle.Enabled() {
+		return lib.threadContextDynamic(spanMap)
 	}
-	return lib.threadContextDynamic(spanMap)
+	return lib.threadContextSnapshot(backupCtx, spanMap)
 }
 
 func (lib *LibraryNoDB) threadContextDynamic(spanMap map[string]string) (context.Context, func()) {

--- a/connection.go
+++ b/connection.go
@@ -966,6 +966,7 @@ var gateEventsThreadContextLifecycle = codegate.New("EventsThreadContextLifecycl
 //   - when Shutdown is called before any library lifecycle contexts are registered
 //
 // The returned context has a span. It is cancelled when the returned done is called.
+// TODO: remove backupCtx when removing gateEventsThreadContextLifecycle.
 func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
 	if !gateEventsThreadContextLifecycle.Enabled() {
 		return lib.threadContextOld(backupCtx, spanMap)

--- a/connection.go
+++ b/connection.go
@@ -120,7 +120,7 @@ type LibraryNoDB struct {
 	ready                     atomic.Int32
 	topicConfig               map[string]kafka.TopicConfig  // un-prefixed
 	topicsWork                pwork.Work[string, topicsWhy] // un-prefixed in APIs
-	topicListingLock          sync.Mutex
+	topicListingStarted       sync.Once
 	topicsHaveBeenListed      chan struct{}
 	mustRegisterTopics        bool
 	hasTxConsumers            bool

--- a/connection.go
+++ b/connection.go
@@ -970,10 +970,6 @@ func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[str
 	if !gateEventsThreadContextLifecycle.Enabled() {
 		return lib.threadContextSnapshot(backupCtx, spanMap)
 	}
-	return lib.threadContextDynamic(spanMap)
-}
-
-func (lib *LibraryNoDB) threadContextDynamic(spanMap map[string]string) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
 	lib.libraryDone.Add(2)

--- a/connection.go
+++ b/connection.go
@@ -967,10 +967,10 @@ var gateEventsThreadContextLifecycle = codegate.New("EventsThreadContextLifecycl
 //
 // The returned context has a span. It is cancelled when the returned done is called.
 func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
-	if gateEventsThreadContextLifecycle.Enabled() {
-		return lib.threadContextDynamic(spanMap)
+	if !gateEventsThreadContextLifecycle.Enabled() {
+		return lib.threadContextSnapshot(backupCtx, spanMap)
 	}
-	return lib.threadContextSnapshot(backupCtx, spanMap)
+	return lib.threadContextDynamic(spanMap)
 }
 
 func (lib *LibraryNoDB) threadContextDynamic(spanMap map[string]string) (context.Context, func()) {

--- a/connection.go
+++ b/connection.go
@@ -473,7 +473,10 @@ func (lib *LibraryNoDB) Shutdown(ctx context.Context) {
 		defer lib.lock.Unlock()
 		lib.lock.Lock()
 		lib.ready.Store(isShutdown)
-		lib.shutdownCancel()
+		if lib.shutdownCancel != nil {
+			lib.shutdownCancel()
+			lib.shutdownCancel = nil
+		}
 		if lib.consumeCtx != nil && lib.consumeCtx.Err() == nil {
 			consumeNotCancelled = true
 		}
@@ -1019,6 +1022,8 @@ func (lib *LibraryNoDB) contextsToWaitFor() ([]context.Context, <-chan struct{})
 	return waitFor, lib.contextUpdate
 }
 
+// notifyContextUpdateLocked broadcasts that consumeCtx or produceCtx was
+// registered or replaced. lib.lock must be held by the caller.
 func (lib *LibraryNoDB) notifyContextUpdateLocked() {
 	close(lib.contextUpdate)
 	lib.contextUpdate = make(chan struct{})

--- a/connection.go
+++ b/connection.go
@@ -19,6 +19,7 @@ import (
 	"github.com/muir/gwrap"
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/sasl"
+	"github.com/singlestore-labs/codegate"
 	"github.com/singlestore-labs/generic"
 	"github.com/singlestore-labs/simultaneous"
 
@@ -86,6 +87,9 @@ var (
 	LegalTopicNames         = regexp.MustCompile(fmt.Sprintf(`^[-._a-zA-Z0-9]{1,%d}$`, maxTopicNameLength))
 	legalConsumerGroupNames = regexp.MustCompile(fmt.Sprintf(`^[-._a-zA-Z0-9]{1,%d}$`, maxConsumerGroupNameLength))
 )
+
+// TODO: remove this code gate once dynamic threadContext lifecycle handling is stable in production.
+var gateEventsThreadContextLifecycle = codegate.New("EventsThreadContextLifecycle")
 
 var instanceCount atomic.Int32
 
@@ -962,7 +966,14 @@ func (lib *LibraryNoDB) logf(ctx context.Context, format string, a ...any) {
 //   - when Shutdown is called before any library lifecycle contexts are registered
 //
 // The returned context has a span. It is cancelled when the returned done is called.
-func (lib *LibraryNoDB) threadContext(spanMap map[string]string) (context.Context, func()) {
+func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
+	if !gateEventsThreadContextLifecycle.Enabled() {
+		return lib.threadContextSnapshot(backupCtx, spanMap)
+	}
+	return lib.threadContextDynamic(spanMap)
+}
+
+func (lib *LibraryNoDB) threadContextDynamic(spanMap map[string]string) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
 	lib.libraryDone.Add(2)
@@ -1002,6 +1013,41 @@ func (lib *LibraryNoDB) threadContext(spanMap map[string]string) (context.Contex
 	}()
 	// We don't call spanDone in the goroutine. Wait for the returned done
 	// function so the caller controls the span lifetime.
+	return ctx, func() {
+		defer lib.libraryDone.Done()
+		defer spanDone()
+		cancel()
+	}
+}
+
+func (lib *LibraryNoDB) threadContextSnapshot(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
+	waitFor := make([]context.Context, 0, 2)
+	lib.lock.Lock()
+	if lib.consumeCtx != nil {
+		waitFor = append(waitFor, lib.consumeCtx)
+	}
+	if lib.produceCtx != nil {
+		waitFor = append(waitFor, lib.produceCtx)
+	}
+	lib.lock.Unlock()
+	if len(waitFor) == 0 {
+		waitFor = append(waitFor, backupCtx)
+	}
+	lib.libraryDone.Add(2)
+	go func() {
+		defer lib.libraryDone.Done()
+		defer cancel()
+		for len(waitFor) > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-waitFor[0].Done():
+				waitFor = waitFor[1:]
+			}
+		}
+	}()
 	return ctx, func() {
 		defer lib.libraryDone.Done()
 		defer spanDone()

--- a/connection.go
+++ b/connection.go
@@ -471,8 +471,8 @@ func (lib *LibraryNoDB) Shutdown(ctx context.Context) {
 	consumeNotCancelled := false
 	produceNotCancelled := false
 	func() {
-		defer lib.lock.Unlock()
 		lib.lock.Lock()
+		defer lib.lock.Unlock()
 		lib.ready.Store(isShutdown)
 		if lib.shutdownCancel != nil {
 			lib.shutdownCancel()

--- a/connection.go
+++ b/connection.go
@@ -144,6 +144,7 @@ type LibraryNoDB struct {
 	prefix                    string // prefixes all topics and consumer groups
 	consumeCtx                context.Context
 	produceCtx                context.Context
+	contextUpdate             chan struct{}
 	libraryDone               sync.WaitGroup
 
 	// lock must be held when....
@@ -259,6 +260,7 @@ func New[ID eventmodels.AbstractID[ID], TX eventmodels.AbstractTX, DB eventmodel
 			doEnhance:                true,
 			instanceID:               instanceCount.Add(1),
 			topicsHaveBeenListed:     make(chan struct{}),
+			contextUpdate:            make(chan struct{}),
 			sizeCapBrokerReady:       make(chan struct{}),
 			sizeCapDefaultAssumed:    1_000_000,
 			tracerProvider:           func(context.Context) eventmodels.Tracer { return log.Printf },
@@ -949,45 +951,72 @@ func (lib *LibraryNoDB) logf(ctx context.Context, format string, a ...any) {
 }
 
 // threadContext cancels the returned context at the earlier of:
-// - when the returned done() func is called
-// - when both consume and catch-up-produce are cancelled
-// The returned context has a span. It is cancelled when the
-// returned done is called.
-// The provided context is only used if there is no consume and
-// no catch-up-produce invocation.
+//   - when the returned done() func is called
+//   - when all registered consume and catch-up-produce contexts are cancelled
+//   - when the provided backup context is cancelled before any library lifecycle
+//     contexts are registered
+//
+// The returned context has a span. It is cancelled when the returned done is called.
 func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
-	waitFor := make([]context.Context, 0, 2)
+	lib.libraryDone.Add(1)
+	go func() {
+		defer lib.libraryDone.Done()
+		defer cancel()
+	Outer:
+		for {
+			waitFor, update := lib.contextsToWaitFor()
+			if len(waitFor) == 0 {
+				select {
+				case <-ctx.Done():
+					// done function used
+					return
+				case <-backupCtx.Done():
+					return
+				case <-update:
+					continue
+				}
+			}
+			for len(waitFor) > 0 {
+				select {
+				case <-ctx.Done():
+					// done function used
+					return
+				case <-update:
+					// A consume or catch-up-produce context was registered while
+					// this thread was already waiting. Re-snapshot so this thread
+					// follows the latest library lifecycle.
+					continue Outer
+				case <-waitFor[0].Done():
+					waitFor = waitFor[1:]
+				}
+			}
+			return
+		}
+	}()
+	// We don't call spanDone in the goroutine. Wait for the returned done
+	// function so the caller controls the span lifetime.
+	return ctx, func() {
+		cancel()
+		spanDone()
+	}
+}
+
+func (lib *LibraryNoDB) contextsToWaitFor() ([]context.Context, <-chan struct{}) {
 	lib.lock.Lock()
 	defer lib.lock.Unlock()
+	waitFor := make([]context.Context, 0, 2)
 	if lib.consumeCtx != nil {
 		waitFor = append(waitFor, lib.consumeCtx)
 	}
 	if lib.produceCtx != nil {
 		waitFor = append(waitFor, lib.produceCtx)
 	}
-	if len(waitFor) == 0 {
-		waitFor = append(waitFor, backupCtx)
-	}
-	lib.libraryDone.Add(1)
-	go func() {
-		defer lib.libraryDone.Done()
-		defer cancel()
-		for len(waitFor) > 0 {
-			select {
-			case <-ctx.Done():
-				// done function used
-				return
-			case <-waitFor[0].Done():
-				waitFor = waitFor[1:]
-			}
-		}
-		// we don't call spanDone yet -- we wait for the cancel to
-		// cause the done function to be called
-	}()
-	return ctx, func() {
-		cancel()
-		spanDone()
-	}
+	return waitFor, lib.contextUpdate
+}
+
+func (lib *LibraryNoDB) notifyContextUpdateLocked() {
+	close(lib.contextUpdate)
+	lib.contextUpdate = make(chan struct{})
 }

--- a/connection.go
+++ b/connection.go
@@ -120,9 +120,9 @@ type LibraryNoDB struct {
 	ready                     atomic.Int32
 	topicConfig               map[string]kafka.TopicConfig  // un-prefixed
 	topicsWork                pwork.Work[string, topicsWhy] // un-prefixed in APIs
-	topicListingStarted       sync.Once
+	topicListingLock          sync.Mutex
+	topicListingAttemptDone   chan struct{}
 	topicsHaveBeenListed      chan struct{}
-	topicsListingErr          error
 	mustRegisterTopics        bool
 	hasTxConsumers            bool
 	clientID                  string

--- a/connection.go
+++ b/connection.go
@@ -1022,33 +1022,35 @@ func (lib *LibraryNoDB) threadContextOld(backupCtx context.Context, spanMap map[
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
 	waitFor := make([]context.Context, 0, 2)
 	lib.lock.Lock()
+	defer lib.lock.Unlock()
 	if lib.consumeCtx != nil {
 		waitFor = append(waitFor, lib.consumeCtx)
 	}
 	if lib.produceCtx != nil {
 		waitFor = append(waitFor, lib.produceCtx)
 	}
-	lib.lock.Unlock()
 	if len(waitFor) == 0 {
 		waitFor = append(waitFor, backupCtx)
 	}
-	lib.libraryDone.Add(2)
+	lib.libraryDone.Add(1)
 	go func() {
 		defer lib.libraryDone.Done()
 		defer cancel()
 		for len(waitFor) > 0 {
 			select {
 			case <-ctx.Done():
+				// done function used
 				return
 			case <-waitFor[0].Done():
 				waitFor = waitFor[1:]
 			}
 		}
+		// we don't call spanDone yet -- we wait for the cancel to
+		// cause the done function to be called
 	}()
 	return ctx, func() {
-		defer lib.libraryDone.Done()
-		defer spanDone()
 		cancel()
+		spanDone()
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -145,6 +145,8 @@ type LibraryNoDB struct {
 	consumeCtx                context.Context
 	produceCtx                context.Context
 	contextUpdate             chan struct{}
+	shutdownCtx               context.Context
+	shutdownCancel            context.CancelFunc
 	libraryDone               sync.WaitGroup
 
 	// lock must be held when....
@@ -243,6 +245,7 @@ type canHandle interface {
 // Configure() and Consume*() may not be used once consumption or production
 // has started.
 func New[ID eventmodels.AbstractID[ID], TX eventmodels.AbstractTX, DB eventmodels.AbstractDB[ID, TX]]() *Library[ID, TX, DB] {
+	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	lib := Library[ID, TX, DB]{
 		produceFromTable: make(chan []ID, produceFromTableBuffer),
 		LibraryNoDB: LibraryNoDB{
@@ -261,6 +264,8 @@ func New[ID eventmodels.AbstractID[ID], TX eventmodels.AbstractTX, DB eventmodel
 			instanceID:               instanceCount.Add(1),
 			topicsHaveBeenListed:     make(chan struct{}),
 			contextUpdate:            make(chan struct{}),
+			shutdownCtx:              shutdownCtx,
+			shutdownCancel:           shutdownCancel,
 			sizeCapBrokerReady:       make(chan struct{}),
 			sizeCapDefaultAssumed:    1_000_000,
 			tracerProvider:           func(context.Context) eventmodels.Tracer { return log.Printf },
@@ -452,10 +457,8 @@ func (lib *Library[ID, TX, DB]) start(ctx context.Context, str string, args ...a
 }
 
 // Shutdown returns when the library is completely shut down.
-// If consumers were never started and a catch up producer was
-// never started, then produce may return before background threads
-// created by produce have completed. Shutdown does not cancel
-// the consume or catch-up-producer contects.
+// Shutdown cancels library-owned background threads. It does not cancel
+// the consume or catch-up-producer contexts.
 func (lib *LibraryNoDB) Shutdown(ctx context.Context) {
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, map[string]string{
 		"action": "wait for shutdown",
@@ -463,28 +466,25 @@ func (lib *LibraryNoDB) Shutdown(ctx context.Context) {
 	defer spanDone()
 	consumeNotCancelled := false
 	produceNotCancelled := false
-	if func() bool {
+	func() {
 		defer lib.lock.Unlock()
 		lib.lock.Lock()
 		lib.ready.Store(isShutdown)
+		lib.shutdownCancel()
 		if lib.consumeCtx != nil && lib.consumeCtx.Err() == nil {
 			consumeNotCancelled = true
 		}
 		if lib.produceCtx != nil && lib.produceCtx.Err() == nil {
 			produceNotCancelled = true
 		}
-		return lib.consumeCtx != nil || lib.produceCtx != nil
-	}() {
-		if consumeNotCancelled {
-			lib.tracerProvider(ctx)("[events] Shutdown called when the consume context has not been cancelled")
-		}
-		if produceNotCancelled {
-			lib.tracerProvider(ctx)("[events] Shutdown called when the catch up producer context has not been cancelled")
-		}
-		// only wait if consumers or catch-up-producer
-		// was started
-		lib.libraryDone.Wait()
+	}()
+	if consumeNotCancelled {
+		lib.tracerProvider(ctx)("[events] Shutdown called when the consume context has not been cancelled")
 	}
+	if produceNotCancelled {
+		lib.tracerProvider(ctx)("[events] Shutdown called when the catch up producer context has not been cancelled")
+	}
+	lib.libraryDone.Wait()
 }
 
 func (lib *Library[ID, TX, DB]) ConfigureBroadcastHeartbeat(dur time.Duration) {
@@ -953,11 +953,10 @@ func (lib *LibraryNoDB) logf(ctx context.Context, format string, a ...any) {
 // threadContext cancels the returned context at the earlier of:
 //   - when the returned done() func is called
 //   - when all registered consume and catch-up-produce contexts are cancelled
-//   - when the provided backup context is cancelled before any library lifecycle
-//     contexts are registered
+//   - when Shutdown is called before any library lifecycle contexts are registered
 //
 // The returned context has a span. It is cancelled when the returned done is called.
-func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[string]string) (context.Context, func()) {
+func (lib *LibraryNoDB) threadContext(_ context.Context, spanMap map[string]string) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx, spanDone := lib.tracerConfig.BeginSpan(ctx, spanMap)
 	lib.libraryDone.Add(1)
@@ -972,7 +971,7 @@ func (lib *LibraryNoDB) threadContext(backupCtx context.Context, spanMap map[str
 				case <-ctx.Done():
 					// done function used
 					return
-				case <-backupCtx.Done():
+				case <-lib.shutdownCtx.Done():
 					return
 				case <-update:
 					continue

--- a/connection.go
+++ b/connection.go
@@ -122,7 +122,7 @@ type LibraryNoDB struct {
 	topicsWork                pwork.Work[string, topicsWhy] // un-prefixed in APIs
 	topicListingStarted       sync.Once
 	topicsHaveBeenListed      chan struct{}
-	topicsListingErr          error
+	topicsListingErr          error // only valid after topicsHaveBeenListed is closed
 	mustRegisterTopics        bool
 	hasTxConsumers            bool
 	clientID                  string

--- a/connection_test.go
+++ b/connection_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -38,12 +39,30 @@ func TestThreadContextAdoptsLateLifecycleContext(t *testing.T) {
 func TestThreadContextWithoutLifecycleLastsUntilShutdown(t *testing.T) {
 	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
 	ctx, done := lib.threadContext(map[string]string{"thread": "test"})
-	defer done()
 
 	assert.Never(t, func() bool {
 		return ctx.Err() != nil
 	}, time.Millisecond*50, time.Millisecond*10)
 
-	lib.Shutdown(context.Background())
-	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		lib.Shutdown(context.Background())
+	}()
+	assert.Eventually(t, func() bool {
+		return errors.Is(ctx.Err(), context.Canceled)
+	}, time.Second, time.Millisecond*10)
+
+	select {
+	case <-shutdownDone:
+		t.Fatal("Shutdown returned before thread context callback was called")
+	default:
+	}
+
+	done()
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Shutdown after thread context callback")
+	}
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -34,3 +34,18 @@ func TestThreadContextAdoptsLateLifecycleContext(t *testing.T) {
 		return ctx1.Err() != nil && ctx2.Err() != nil
 	}, time.Second, time.Millisecond*10)
 }
+
+func TestThreadContextWithoutLifecycleLastsUntilShutdown(t *testing.T) {
+	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
+	backupCtx, cancelBackup := context.WithCancel(context.Background())
+	ctx, done := lib.threadContext(backupCtx, map[string]string{"thread": "test"})
+	defer done()
+
+	cancelBackup()
+	assert.Never(t, func() bool {
+		return ctx.Err() != nil
+	}, time.Millisecond*50, time.Millisecond*10)
+
+	lib.Shutdown(context.Background())
+	assert.ErrorIs(t, ctx.Err(), context.Canceled)
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -18,9 +18,9 @@ func TestConstants(t *testing.T) {
 
 func TestThreadContextAdoptsLateLifecycleContext(t *testing.T) {
 	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
-	ctx1, done1 := lib.threadContext(context.Background(), map[string]string{"thread": "test 1"})
+	ctx1, done1 := lib.threadContext(map[string]string{"thread": "test 1"})
 	defer done1()
-	ctx2, done2 := lib.threadContext(context.Background(), map[string]string{"thread": "test 2"})
+	ctx2, done2 := lib.threadContext(map[string]string{"thread": "test 2"})
 	defer done2()
 
 	consumeCtx, cancelConsume := context.WithCancel(context.Background())
@@ -37,11 +37,9 @@ func TestThreadContextAdoptsLateLifecycleContext(t *testing.T) {
 
 func TestThreadContextWithoutLifecycleLastsUntilShutdown(t *testing.T) {
 	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
-	backupCtx, cancelBackup := context.WithCancel(context.Background())
-	ctx, done := lib.threadContext(backupCtx, map[string]string{"thread": "test"})
+	ctx, done := lib.threadContext(map[string]string{"thread": "test"})
 	defer done()
 
-	cancelBackup()
 	assert.Never(t, func() bool {
 		return ctx.Err() != nil
 	}, time.Millisecond*50, time.Millisecond*10)

--- a/connection_test.go
+++ b/connection_test.go
@@ -19,9 +19,9 @@ func TestConstants(t *testing.T) {
 
 func TestThreadContextAdoptsLateLifecycleContext(t *testing.T) {
 	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
-	ctx1, done1 := lib.threadContext(map[string]string{"thread": "test 1"})
+	ctx1, done1 := lib.threadContext(context.Background(), map[string]string{"thread": "test 1"})
 	defer done1()
-	ctx2, done2 := lib.threadContext(map[string]string{"thread": "test 2"})
+	ctx2, done2 := lib.threadContext(context.Background(), map[string]string{"thread": "test 2"})
 	defer done2()
 
 	consumeCtx, cancelConsume := context.WithCancel(context.Background())
@@ -38,7 +38,7 @@ func TestThreadContextAdoptsLateLifecycleContext(t *testing.T) {
 
 func TestThreadContextWithoutLifecycleLastsUntilShutdown(t *testing.T) {
 	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
-	ctx, done := lib.threadContext(map[string]string{"thread": "test"})
+	ctx, done := lib.threadContext(context.Background(), map[string]string{"thread": "test"})
 
 	assert.Never(t, func() bool {
 		return ctx.Err() != nil
@@ -69,7 +69,7 @@ func TestThreadContextWithoutLifecycleLastsUntilShutdown(t *testing.T) {
 
 func TestShutdownCanBeCalledTwice(t *testing.T) {
 	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
-	ctx, done := lib.threadContext(map[string]string{"thread": "test"})
+	ctx, done := lib.threadContext(context.Background(), map[string]string{"thread": "test"})
 
 	shutdownDone := make(chan struct{})
 	go func() {

--- a/connection_test.go
+++ b/connection_test.go
@@ -66,3 +66,34 @@ func TestThreadContextWithoutLifecycleLastsUntilShutdown(t *testing.T) {
 		t.Fatal("timed out waiting for Shutdown after thread context callback")
 	}
 }
+
+func TestShutdownCanBeCalledTwice(t *testing.T) {
+	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
+	ctx, done := lib.threadContext(map[string]string{"thread": "test"})
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		lib.Shutdown(context.Background())
+	}()
+	assert.Eventually(t, func() bool {
+		return errors.Is(ctx.Err(), context.Canceled)
+	}, time.Second, time.Millisecond*10)
+	done()
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first Shutdown")
+	}
+
+	secondShutdownDone := make(chan struct{})
+	go func() {
+		defer close(secondShutdownDone)
+		lib.Shutdown(context.Background())
+	}()
+	select {
+	case <-secondShutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for second Shutdown")
+	}
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,9 +1,11 @@
 package events
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/singlestore-labs/events/eventmodels"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,4 +14,23 @@ func TestConstants(t *testing.T) {
 	assert.Greater(t, broadcastReaderIdleTimeout, time.Second)
 	assert.Less(t, broadcastHeartbeatRandom, 0.8)
 	assert.Less(t, maxConsumerGroupNameLength, 56)
+}
+
+func TestThreadContextAdoptsLateLifecycleContext(t *testing.T) {
+	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
+	ctx1, done1 := lib.threadContext(context.Background(), map[string]string{"thread": "test 1"})
+	defer done1()
+	ctx2, done2 := lib.threadContext(context.Background(), map[string]string{"thread": "test 2"})
+	defer done2()
+
+	consumeCtx, cancelConsume := context.WithCancel(context.Background())
+	lib.lock.Lock()
+	lib.consumeCtx = consumeCtx
+	lib.notifyContextUpdateLocked()
+	lib.lock.Unlock()
+
+	cancelConsume()
+	assert.Eventually(t, func() bool {
+		return ctx1.Err() != nil && ctx2.Err() != nil
+	}, time.Second, time.Millisecond*10)
 }

--- a/consume.go
+++ b/consume.go
@@ -128,6 +128,7 @@ func (lib *Library[ID, TX, DB]) startConsuming(baseCtx context.Context, waitForS
 		lib.lock.Lock()
 		defer lib.lock.Unlock()
 		lib.consumeCtx = baseCtx
+		lib.notifyContextUpdateLocked()
 	}()
 	for _, group := range lib.readers {
 		for topic := range group.topics {

--- a/consume.go
+++ b/consume.go
@@ -13,6 +13,7 @@ import (
 	"github.com/memsql/errors"
 	"github.com/muir/gwrap"
 	"github.com/segmentio/kafka-go"
+	"github.com/singlestore-labs/codegate"
 	"github.com/singlestore-labs/events/eventmodels"
 	"github.com/singlestore-labs/generic"
 	"github.com/singlestore-labs/once"
@@ -31,17 +32,27 @@ type eventLimiterType struct{}
 
 type limit = simultaneous.Limit[eventLimiterType]
 
-var backoffPolicy = backoff.Exponential(
+// TODO: remove this code gate once infinite retries are stable for existing backoff loops.
+var gateEventsExistingBackoffInfiniteRetries = codegate.New("EventsExistingBackoffInfiniteRetries")
+
+var backoffPolicy = backoff.Exponential(existingBackoffOptions(gateEventsExistingBackoffInfiniteRetries,
 	backoff.WithMinInterval(time.Second),
 	backoff.WithMaxInterval(time.Second*30),
 	backoff.WithJitterFactor(0.05),
-)
+)...)
 
-var deadLetterBackoffPolicy = backoff.Exponential(
+var deadLetterBackoffPolicy = backoff.Exponential(existingBackoffOptions(gateEventsExistingBackoffInfiniteRetries,
 	backoff.WithMinInterval(time.Second),
 	backoff.WithMaxInterval(time.Minute*30),
 	backoff.WithJitterFactor(0.05),
-)
+)...)
+
+func existingBackoffOptions(gate codegate.Gate, opts ...backoff.ExponentialOption) []backoff.ExponentialOption {
+	if gate.Enabled() {
+		opts = append(opts, backoff.WithMaxRetries(0))
+	}
+	return opts
+}
 
 // StartConsumingOrPanic is a wapper around StartConsuming that returns only after the consumers
 // have started. If StartConsuming returns error, it panics.

--- a/eventtest/batch.go
+++ b/eventtest/batch.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	smallBatchSleep = time.Millisecond * 600
-	eventsToSend    = 200
-	maxWait         = 30 * time.Second
+	smallBatchSleep  = time.Millisecond * 600
+	eventsToSend     = 200
+	maxWait          = 30 * time.Second
+	broadcastMaxWait = 75 * time.Second
 )
 
 type batchDeliveryInfo struct {
@@ -76,6 +77,7 @@ func runTest[ID eventmodels.AbstractID[ID], TX eventmodels.EnhancedTX, DB Augmen
 	events []eventmodels.ProducingEvent,
 	cancel Cancel,
 	info *batchDeliveryInfo,
+	deliveryWait time.Duration,
 ) {
 	defer cancel()
 
@@ -109,7 +111,7 @@ func runTest[ID eventmodels.AbstractID[ID], TX eventmodels.EnhancedTX, DB Augmen
 		require.FailNow(t, "timeout", "aborted waiting for completion")
 	case <-info.done:
 		t.Log("delivery completed")
-	case <-time.After(maxWait):
+	case <-time.After(deliveryWait):
 		t.Log("timeout")
 		require.FailNow(t, "timeout", "aborted waiting for completion")
 	}
@@ -186,7 +188,7 @@ func BatchDeliveryIdempotentTest[
 	info, handler := createHandler[ID, TX, DB](t, "idempotent")
 	lib.ConsumeIdempotent(consumerGroup, eventmodels.OnFailureDiscard, Name(t)+"-CI", topic.BatchHandler(handler))
 
-	runTest(ctx, t, lib, events, cancel, info)
+	runTest(ctx, t, lib, events, cancel, info, maxWait)
 }
 
 func BatchDeliveryBroadcastTest[
@@ -206,7 +208,7 @@ func BatchDeliveryBroadcastTest[
 	info, handler := createHandler[ID, TX, DB](t, "broadcast")
 	lib.ConsumeBroadcast(Name(t)+"CB", topic.BatchHandler(handler))
 
-	runTest(ctx, t, lib, events, cancel, info)
+	runTest(ctx, t, lib, events, cancel, info, broadcastMaxWait)
 }
 
 func BatchDeliveryExactlyOnceTest[
@@ -232,5 +234,5 @@ func BatchDeliveryExactlyOnceTest[
 			return handler(ctx, events)
 		}))
 
-	runTest(ctx, t, lib, events, cancel, info)
+	runTest(ctx, t, lib, events, cancel, info, maxWait)
 }

--- a/eventtest/batch.go
+++ b/eventtest/batch.go
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	smallBatchSleep  = time.Millisecond * 600
-	eventsToSend     = 200
-	maxWait          = 30 * time.Second
-	broadcastMaxWait = 75 * time.Second
+	smallBatchSleep        = time.Millisecond * 600
+	eventsToSend           = 200
+	maxWait                = 30 * time.Second
+	broadcastMaxWait       = 75 * time.Second
+	broadcastTestHeartbeat = broadcastMaxWait * 2
 )
 
 type batchDeliveryInfo struct {
@@ -206,6 +207,9 @@ func BatchDeliveryBroadcastTest[
 	t, lib, topic, _, events := batchTestCommon(ctx, t, conn, brokers, "BDB", prefix)
 
 	info, handler := createHandler[ID, TX, DB](t, "broadcast")
+	// Avoid masking the broadcast reader idle timeout with heartbeat traffic while
+	// this test is waiting for application-topic delivery.
+	lib.ConfigureBroadcastHeartbeat(broadcastTestHeartbeat)
 	lib.ConsumeBroadcast(Name(t)+"CB", topic.BatchHandler(handler))
 
 	runTest(ctx, t, lib, events, cancel, info, broadcastMaxWait)

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/segmentio/kafka-go v0.4.51
 	github.com/sharnoff/eventdistributor v0.1.1
+	github.com/singlestore-labs/codegate v0.1.0
 	github.com/singlestore-labs/generic v0.5.0
 	github.com/singlestore-labs/once v0.0.1
 	github.com/singlestore-labs/simultaneous v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/segmentio/kafka-go v0.4.51 h1:JgDPPG75tC1rWIS2Me6MwcvXJ6f49UQ4HjAOef7
 github.com/segmentio/kafka-go v0.4.51/go.mod h1:Y1gn60kzLEEaW28YshXyk2+VCUKbJ3Qr6DrnT3i4+9E=
 github.com/sharnoff/eventdistributor v0.1.1 h1:7OOcn2f9w5zGCjHm8KcIYKyp6y+W7xTNvo7rgnhWvvg=
 github.com/sharnoff/eventdistributor v0.1.1/go.mod h1:OEKtalwdvbR4ZSEkNzMUTcu5aSaW+jRHjmamBlyTcqk=
+github.com/singlestore-labs/codegate v0.1.0 h1:8ILvtkzKUe/PpdE46rn3WNzLKSPpYpXAz4XWSGikmCQ=
+github.com/singlestore-labs/codegate v0.1.0/go.mod h1:tWRAsZch276Z1hD3Xg1fXtunldcI6ROkcDRhz/8PB9I=
 github.com/singlestore-labs/generic v0.5.0 h1:YlWevDHXPxYnIaN/nH+LSW5N4pvP5JGztQDtqmRVNhE=
 github.com/singlestore-labs/generic v0.5.0/go.mod h1:EYP3HOfc9BcytHJMwwQsc99fR6EXxCd13B1egFCF3BQ=
 github.com/singlestore-labs/once v0.0.1 h1:GGfXqAm1+Aywxo2fSNBgMWN+8H/M/VpbbPgVN8Berto=

--- a/limits.go
+++ b/limits.go
@@ -72,7 +72,7 @@ func (lib *Library[ID, TX, DB]) prepareToProduce(ctx context.Context, messages [
 	if maxPayload <= lib.sizeCapDefaultAssumed {
 		// Fire off background fetch; do not block. Reuse provided context.
 		go func() {
-			threadCtx, threadDone := lib.threadContext(ctx, map[string]string{
+			threadCtx, threadDone := lib.threadContext(map[string]string{
 				"action": "thread",
 				"thread": "pre-fetch topic size caps",
 			})
@@ -134,7 +134,7 @@ func (lib *LibraryNoDB) sizeCapStartBrokerCaps(ctx context.Context) {
 // sizeCapLoadBrokerCaps performs DescribeConfigs for broker-level size limits
 func (lib *LibraryNoDB) sizeCapLoadBrokerCaps(ctx context.Context) {
 	defer lib.libraryDone.Done()
-	ctx, threadDone := lib.threadContext(ctx, map[string]string{
+	ctx, threadDone := lib.threadContext(map[string]string{
 		"action": "thread",
 		"thread": "load broker size caps",
 	})
@@ -260,7 +260,9 @@ func (lib *LibraryNoDB) sizeCapBrokerEffective(ctx context.Context) int64 {
 func (lib *LibraryNoDB) configureSizeCapPrework() {
 	lib.sizeCapWork.MaxSimultaneous = 20
 	lib.sizeCapWork.BackoffPolicy = highLimitBackoffPolicy
-	lib.sizeCapWork.ThreadContext = lib.threadContext
+	lib.sizeCapWork.ThreadContext = func(_ context.Context, spanMap map[string]string) (context.Context, func()) {
+		return lib.threadContext(spanMap)
+	}
 	lib.sizeCapWork.WorkDeadline = topicCreationDeadline
 	lib.sizeCapWork.ItemRetryDelay = 5 * time.Second
 	lib.sizeCapWork.ErrorReporter = func(ctx context.Context, err error, _ string) {

--- a/limits.go
+++ b/limits.go
@@ -72,7 +72,7 @@ func (lib *Library[ID, TX, DB]) prepareToProduce(ctx context.Context, messages [
 	if maxPayload <= lib.sizeCapDefaultAssumed {
 		// Fire off background fetch; do not block. Reuse provided context.
 		go func() {
-			threadCtx, threadDone := lib.threadContext(map[string]string{
+			threadCtx, threadDone := lib.threadContext(ctx, map[string]string{
 				"action": "thread",
 				"thread": "pre-fetch topic size caps",
 			})
@@ -132,9 +132,9 @@ func (lib *LibraryNoDB) sizeCapStartBrokerCaps(ctx context.Context) {
 }
 
 // sizeCapLoadBrokerCaps performs DescribeConfigs for broker-level size limits
-func (lib *LibraryNoDB) sizeCapLoadBrokerCaps(_ context.Context) {
+func (lib *LibraryNoDB) sizeCapLoadBrokerCaps(ctx context.Context) {
 	defer lib.libraryDone.Done()
-	ctx, threadDone := lib.threadContext(map[string]string{
+	ctx, threadDone := lib.threadContext(ctx, map[string]string{
 		"action": "thread",
 		"thread": "load broker size caps",
 	})
@@ -260,9 +260,7 @@ func (lib *LibraryNoDB) sizeCapBrokerEffective(ctx context.Context) int64 {
 func (lib *LibraryNoDB) configureSizeCapPrework() {
 	lib.sizeCapWork.MaxSimultaneous = 20
 	lib.sizeCapWork.BackoffPolicy = highLimitBackoffPolicy
-	lib.sizeCapWork.ThreadContext = func(_ context.Context, spanMap map[string]string) (context.Context, func()) {
-		return lib.threadContext(spanMap)
-	}
+	lib.sizeCapWork.ThreadContext = lib.threadContext
 	lib.sizeCapWork.WorkDeadline = topicCreationDeadline
 	lib.sizeCapWork.ItemRetryDelay = 5 * time.Second
 	lib.sizeCapWork.ErrorReporter = func(ctx context.Context, err error, _ string) {

--- a/limits.go
+++ b/limits.go
@@ -132,7 +132,7 @@ func (lib *LibraryNoDB) sizeCapStartBrokerCaps(ctx context.Context) {
 }
 
 // sizeCapLoadBrokerCaps performs DescribeConfigs for broker-level size limits
-func (lib *LibraryNoDB) sizeCapLoadBrokerCaps(ctx context.Context) {
+func (lib *LibraryNoDB) sizeCapLoadBrokerCaps(_ context.Context) {
 	defer lib.libraryDone.Done()
 	ctx, threadDone := lib.threadContext(map[string]string{
 		"action": "thread",

--- a/limits.go
+++ b/limits.go
@@ -28,11 +28,11 @@ const (
 	debugLimits = false
 )
 
-var highLimitBackoffPolicy = backoff.Exponential(
+var highLimitBackoffPolicy = backoff.Exponential(existingBackoffOptions(gateEventsExistingBackoffInfiniteRetries,
 	backoff.WithMinInterval(time.Second*4),
 	backoff.WithMaxInterval(time.Second*1800),
 	backoff.WithJitterFactor(0.05),
-)
+)...)
 
 // prepareToProduce makes sure that all topics are created and if
 // there are any messages that are >1MB, it makes sure that the message size

--- a/produce.go
+++ b/produce.go
@@ -267,6 +267,7 @@ func (lib *Library[ID, TX, DB]) CatchUpProduce(ctx context.Context, sleepTime ti
 		lib.lock.Lock()
 		defer lib.lock.Unlock()
 		lib.produceCtx = ctx
+		lib.notifyContextUpdateLocked()
 	}()
 	if !lib.HasDB() {
 		close(done)

--- a/topics.go
+++ b/topics.go
@@ -10,7 +10,6 @@ import (
 	"github.com/memsql/errors"
 	"github.com/segmentio/kafka-go"
 
-	"github.com/singlestore-labs/codegate"
 	"github.com/singlestore-labs/events/internal/pwork"
 	"github.com/singlestore-labs/generic"
 )
@@ -35,22 +34,12 @@ const (
 	debugLogTopicsMissingPrefix = false
 )
 
-// TODO: remove this code gate once infinite topic-listing retries are stable in production.
-var gateEventsTopicListingInfiniteRetries = codegate.New("EventsTopicListingInfiniteRetries")
-
-var topicListingBackoffPolicy = newTopicListingBackoffPolicy()
-
-func newTopicListingBackoffPolicy() backoff.Policy {
-	opts := []backoff.ExponentialOption{
-		backoff.WithMinInterval(time.Second),
-		backoff.WithMaxInterval(time.Second * 30),
-		backoff.WithJitterFactor(0.05),
-	}
-	if gateEventsTopicListingInfiniteRetries.Enabled() {
-		opts = append(opts, backoff.WithMaxRetries(0))
-	}
-	return backoff.Exponential(opts...)
-}
+var topicListingBackoffPolicy = backoff.Exponential(
+	backoff.WithMinInterval(time.Second),
+	backoff.WithMaxInterval(time.Second*30),
+	backoff.WithJitterFactor(0.05),
+	backoff.WithMaxRetries(0),
+)
 
 // UnregisteredTopicError is the base error when attempting to create a
 // topic that isn't pre-preregistered when pre-registration is required.

--- a/topics.go
+++ b/topics.go
@@ -249,25 +249,21 @@ func (lib *LibraryNoDB) configureTopicsPrework() {
 	}
 }
 
-func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) {
-	defer close(lib.topicsHaveBeenListed)
+func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) error {
 	dialer := lib.dialer()
-	listingCtx := context.WithoutCancel(ctx)
-	b := topicListingBackoffPolicy.Start(listingCtx)
+	b := topicListingBackoffPolicy.Start(ctx)
 	for backoff.Continue(b) {
 		lib.logf(ctx, "[events] starting over on listing topics")
 		for _, i := range rand.Perm(len(lib.brokers)) {
 			broker := lib.brokers[i]
 			lib.logf(ctx, "[events] connecting to %s to list topics", broker)
-			conn, err := dialer.DialContext(listingCtx, "tcp", broker)
+			conn, err := dialer.DialContext(ctx, "tcp", broker)
 			if err != nil {
 				lib.logf(ctx, "[events] could not connect to broker %s, was going to list topics: %v", broker, err)
 				continue
 			}
-			defer func() {
-				_ = conn.Close()
-			}()
 			partitions, err := conn.ReadPartitions()
+			_ = conn.Close()
 			if err != nil {
 				lib.logf(ctx, "[events] could not list partitions on broker %s: %v", broker, err)
 				continue
@@ -290,19 +286,24 @@ func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) {
 				lib.topicsWork.SetDone(unprefixedTopic)
 			}
 			lib.logf(ctx, "[events] done listing existing topics")
-			return
+			return nil
 		}
 		lib.logf(ctx, "[events] waiting before making another attempt to list topics")
 	}
+	if err := ctx.Err(); err != nil {
+		return errors.Errorf("event library could not list kafka topics from any broker: %w", err)
+	}
+	return errors.Errorf("event library could not list kafka topics from any broker")
 }
 
 func (lib *LibraryNoDB) waitForTopicsListing(ctx context.Context) error {
 	lib.topicListingStarted.Do(func() {
-		lib.listAvailableTopics(ctx)
+		lib.topicsListingErr = lib.listAvailableTopics(ctx)
+		close(lib.topicsHaveBeenListed)
 	})
 	select {
 	case <-lib.topicsHaveBeenListed:
-		return nil
+		return lib.topicsListingErr
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/topics.go
+++ b/topics.go
@@ -297,15 +297,48 @@ func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) error {
 }
 
 func (lib *LibraryNoDB) waitForTopicsListing(ctx context.Context) error {
-	lib.topicListingStarted.Do(func() {
-		lib.topicsListingErr = lib.listAvailableTopics(ctx)
-		close(lib.topicsHaveBeenListed)
-	})
-	select {
-	case <-lib.topicsHaveBeenListed:
-		return lib.topicsListingErr
-	case <-ctx.Done():
-		return ctx.Err()
+	for {
+		select {
+		case <-lib.topicsHaveBeenListed:
+			return nil
+		default:
+		}
+
+		lib.topicListingLock.Lock()
+		select {
+		case <-lib.topicsHaveBeenListed:
+			lib.topicListingLock.Unlock()
+			return nil
+		default:
+		}
+		if lib.topicListingAttemptDone == nil {
+			done := make(chan struct{})
+			lib.topicListingAttemptDone = done
+			lib.topicListingLock.Unlock()
+
+			err := lib.listAvailableTopics(ctx)
+
+			lib.topicListingLock.Lock()
+			if err == nil {
+				close(lib.topicsHaveBeenListed)
+			}
+			if lib.topicListingAttemptDone == done {
+				lib.topicListingAttemptDone = nil
+			}
+			close(done)
+			lib.topicListingLock.Unlock()
+			return err
+		}
+		done := lib.topicListingAttemptDone
+		lib.topicListingLock.Unlock()
+
+		select {
+		case <-lib.topicsHaveBeenListed:
+			return nil
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 

--- a/topics.go
+++ b/topics.go
@@ -306,16 +306,20 @@ func (lib *LibraryNoDB) waitForTopicsListing(ctx context.Context) error {
 		})
 		go func() {
 			defer threadDone()
-			if err := lib.listAvailableTopics(threadCtx); err == nil {
-				close(lib.topicsHaveBeenListed)
-			}
+			lib.topicsListingErr = lib.listAvailableTopics(threadCtx)
+			close(lib.topicsHaveBeenListed)
 		}()
 	})
 	select {
 	case <-lib.topicsHaveBeenListed:
-		return nil
+		return lib.topicsListingErr
 	case <-ctx.Done():
-		return ctx.Err()
+		select {
+		case <-lib.topicsHaveBeenListed:
+			return lib.topicsListingErr
+		default:
+			return ctx.Err()
+		}
 	}
 }
 

--- a/topics.go
+++ b/topics.go
@@ -298,7 +298,9 @@ func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) error {
 
 func (lib *LibraryNoDB) waitForTopicsListing(ctx context.Context) error {
 	lib.topicListingStarted.Do(func() {
-		threadCtx, threadDone := lib.threadContext(ctx, map[string]string{
+		// The listing thread is library-owned. Individual callers may stop waiting
+		// via ctx, but must not cancel the one shared listing attempt.
+		threadCtx, threadDone := lib.threadContext(context.Background(), map[string]string{
 			"action": "thread",
 			"thread": "list available topics",
 		})

--- a/topics.go
+++ b/topics.go
@@ -297,48 +297,23 @@ func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) error {
 }
 
 func (lib *LibraryNoDB) waitForTopicsListing(ctx context.Context) error {
-	for {
-		select {
-		case <-lib.topicsHaveBeenListed:
-			return nil
-		default:
-		}
-
-		lib.topicListingLock.Lock()
-		select {
-		case <-lib.topicsHaveBeenListed:
-			lib.topicListingLock.Unlock()
-			return nil
-		default:
-		}
-		if lib.topicListingAttemptDone == nil {
-			done := make(chan struct{})
-			lib.topicListingAttemptDone = done
-			lib.topicListingLock.Unlock()
-
-			err := lib.listAvailableTopics(ctx)
-
-			lib.topicListingLock.Lock()
-			if err == nil {
+	lib.topicListingStarted.Do(func() {
+		threadCtx, threadDone := lib.threadContext(ctx, map[string]string{
+			"action": "thread",
+			"thread": "list available topics",
+		})
+		go func() {
+			defer threadDone()
+			if err := lib.listAvailableTopics(threadCtx); err == nil {
 				close(lib.topicsHaveBeenListed)
 			}
-			if lib.topicListingAttemptDone == done {
-				lib.topicListingAttemptDone = nil
-			}
-			close(done)
-			lib.topicListingLock.Unlock()
-			return err
-		}
-		done := lib.topicListingAttemptDone
-		lib.topicListingLock.Unlock()
-
-		select {
-		case <-lib.topicsHaveBeenListed:
-			return nil
-		case <-done:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		}()
+	})
+	select {
+	case <-lib.topicsHaveBeenListed:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/topics.go
+++ b/topics.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/lestrrat-go/backoff/v2"
 	"github.com/memsql/errors"
 	"github.com/segmentio/kafka-go"
 
@@ -31,6 +32,13 @@ const (
 	defaultNumPartitions        = 2
 	defaultReplicationFactor    = 3
 	debugLogTopicsMissingPrefix = false
+)
+
+var topicListingBackoffPolicy = backoff.Exponential(
+	backoff.WithMinInterval(time.Second),
+	backoff.WithMaxInterval(time.Second*30),
+	backoff.WithJitterFactor(0.05),
+	backoff.WithMaxRetries(0),
 )
 
 // UnregisteredTopicError is the base error when attempting to create a
@@ -241,24 +249,37 @@ func (lib *LibraryNoDB) configureTopicsPrework() {
 	}
 }
 
-func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) error {
+func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) {
 	dialer := lib.dialer()
-	for {
+	lib.listAvailableTopicsWith(ctx, func(listingCtx context.Context, broker string) ([]kafka.Partition, bool) {
+		conn, err := dialer.DialContext(listingCtx, "tcp", broker)
+		if err != nil {
+			lib.logf(ctx, "[events] could not connect to broker %s, was going to list topics: %v", broker, err)
+			return nil, false
+		}
+		defer func() {
+			_ = conn.Close()
+		}()
+		partitions, err := conn.ReadPartitions()
+		if err != nil {
+			lib.logf(ctx, "[events] could not list partitions on broker %s: %v", broker, err)
+			return nil, false
+		}
+		return partitions, true
+	})
+}
+
+func (lib *LibraryNoDB) listAvailableTopicsWith(ctx context.Context, listBroker func(context.Context, string) ([]kafka.Partition, bool)) {
+	defer close(lib.topicsHaveBeenListed)
+	listingCtx := context.WithoutCancel(ctx)
+	b := topicListingBackoffPolicy.Start(listingCtx)
+	for backoff.Continue(b) {
 		lib.logf(ctx, "[events] starting over on listing topics")
 		for _, i := range rand.Perm(len(lib.brokers)) {
 			broker := lib.brokers[i]
 			lib.logf(ctx, "[events] connecting to %s to list topics", broker)
-			conn, err := dialer.DialContext(ctx, "tcp", broker)
-			if err != nil {
-				lib.logf(ctx, "[events] could not connect to broker %s, was going to list topics: %v", broker, err)
-				continue
-			}
-			defer func() {
-				_ = conn.Close()
-			}()
-			partitions, err := conn.ReadPartitions()
-			if err != nil {
-				lib.logf(ctx, "[events] could not list partitions on broker %s: %v", broker, err)
+			partitions, ok := listBroker(listingCtx, broker)
+			if !ok {
 				continue
 			}
 			lib.logf(ctx, "[events] listing existing topics...")
@@ -279,37 +300,22 @@ func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) error {
 				lib.topicsWork.SetDone(unprefixedTopic)
 			}
 			lib.logf(ctx, "[events] done listing existing topics")
-			close(lib.topicsHaveBeenListed)
-			return nil
+			return
 		}
 		lib.logf(ctx, "[events] waiting before making another attempt to list topics")
-		timer := time.NewTimer(topicCreateSleepTime)
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		}
 	}
 }
 
 func (lib *LibraryNoDB) waitForTopicsListing(ctx context.Context) error {
+	lib.topicListingStarted.Do(func() {
+		lib.listAvailableTopics(ctx)
+	})
 	select {
 	case <-lib.topicsHaveBeenListed:
 		return nil
-	default:
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-
-	lib.topicListingLock.Lock()
-	defer lib.topicListingLock.Unlock()
-
-	select {
-	case <-lib.topicsHaveBeenListed:
-		return nil
-	default:
-	}
-
-	return lib.listAvailableTopics(ctx)
 }
 
 // CreateTopics orechestrates the creation of topics that have not already been successfully

--- a/topics.go
+++ b/topics.go
@@ -10,6 +10,7 @@ import (
 	"github.com/memsql/errors"
 	"github.com/segmentio/kafka-go"
 
+	"github.com/singlestore-labs/codegate"
 	"github.com/singlestore-labs/events/internal/pwork"
 	"github.com/singlestore-labs/generic"
 )
@@ -34,12 +35,22 @@ const (
 	debugLogTopicsMissingPrefix = false
 )
 
-var topicListingBackoffPolicy = backoff.Exponential(
-	backoff.WithMinInterval(time.Second),
-	backoff.WithMaxInterval(time.Second*30),
-	backoff.WithJitterFactor(0.05),
-	backoff.WithMaxRetries(0),
-)
+// TODO: remove this code gate once infinite topic-listing retries are stable in production.
+var gateEventsTopicListingInfiniteRetries = codegate.New("EventsTopicListingInfiniteRetries")
+
+var topicListingBackoffPolicy = newTopicListingBackoffPolicy()
+
+func newTopicListingBackoffPolicy() backoff.Policy {
+	opts := []backoff.ExponentialOption{
+		backoff.WithMinInterval(time.Second),
+		backoff.WithMaxInterval(time.Second * 30),
+		backoff.WithJitterFactor(0.05),
+	}
+	if gateEventsTopicListingInfiniteRetries.Enabled() {
+		opts = append(opts, backoff.WithMaxRetries(0))
+	}
+	return backoff.Exponential(opts...)
+}
 
 // UnregisteredTopicError is the base error when attempting to create a
 // topic that isn't pre-preregistered when pre-registration is required.

--- a/topics.go
+++ b/topics.go
@@ -241,15 +241,14 @@ func (lib *LibraryNoDB) configureTopicsPrework() {
 	}
 }
 
-func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) {
-	defer close(lib.topicsHaveBeenListed)
+func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) error {
 	dialer := lib.dialer()
 	for {
 		lib.logf(ctx, "[events] starting over on listing topics")
 		for _, i := range rand.Perm(len(lib.brokers)) {
 			broker := lib.brokers[i]
 			lib.logf(ctx, "[events] connecting to %s to list topics", broker)
-			conn, err := dialer.Dial("tcp", broker)
+			conn, err := dialer.DialContext(ctx, "tcp", broker)
 			if err != nil {
 				lib.logf(ctx, "[events] could not connect to broker %s, was going to list topics: %v", broker, err)
 				continue
@@ -280,22 +279,37 @@ func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) {
 				lib.topicsWork.SetDone(unprefixedTopic)
 			}
 			lib.logf(ctx, "[events] done listing existing topics")
-			return
+			close(lib.topicsHaveBeenListed)
+			return nil
 		}
 		lib.logf(ctx, "[events] waiting before making another attempt to list topics")
+		timer := time.NewTimer(topicCreateSleepTime)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		}
 	}
 }
 
 func (lib *LibraryNoDB) waitForTopicsListing(ctx context.Context) error {
-	lib.topicListingStarted.Do(func() {
-		lib.listAvailableTopics(ctx)
-	})
 	select {
 	case <-lib.topicsHaveBeenListed:
 		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	default:
 	}
+
+	lib.topicListingLock.Lock()
+	defer lib.topicListingLock.Unlock()
+
+	select {
+	case <-lib.topicsHaveBeenListed:
+		return nil
+	default:
+	}
+
+	return lib.listAvailableTopics(ctx)
 }
 
 // CreateTopics orechestrates the creation of topics that have not already been successfully

--- a/topics.go
+++ b/topics.go
@@ -250,27 +250,8 @@ func (lib *LibraryNoDB) configureTopicsPrework() {
 }
 
 func (lib *LibraryNoDB) listAvailableTopics(ctx context.Context) {
-	dialer := lib.dialer()
-	lib.listAvailableTopicsWith(ctx, func(listingCtx context.Context, broker string) ([]kafka.Partition, bool) {
-		conn, err := dialer.DialContext(listingCtx, "tcp", broker)
-		if err != nil {
-			lib.logf(ctx, "[events] could not connect to broker %s, was going to list topics: %v", broker, err)
-			return nil, false
-		}
-		defer func() {
-			_ = conn.Close()
-		}()
-		partitions, err := conn.ReadPartitions()
-		if err != nil {
-			lib.logf(ctx, "[events] could not list partitions on broker %s: %v", broker, err)
-			return nil, false
-		}
-		return partitions, true
-	})
-}
-
-func (lib *LibraryNoDB) listAvailableTopicsWith(ctx context.Context, listBroker func(context.Context, string) ([]kafka.Partition, bool)) {
 	defer close(lib.topicsHaveBeenListed)
+	dialer := lib.dialer()
 	listingCtx := context.WithoutCancel(ctx)
 	b := topicListingBackoffPolicy.Start(listingCtx)
 	for backoff.Continue(b) {
@@ -278,8 +259,17 @@ func (lib *LibraryNoDB) listAvailableTopicsWith(ctx context.Context, listBroker 
 		for _, i := range rand.Perm(len(lib.brokers)) {
 			broker := lib.brokers[i]
 			lib.logf(ctx, "[events] connecting to %s to list topics", broker)
-			partitions, ok := listBroker(listingCtx, broker)
-			if !ok {
+			conn, err := dialer.DialContext(listingCtx, "tcp", broker)
+			if err != nil {
+				lib.logf(ctx, "[events] could not connect to broker %s, was going to list topics: %v", broker, err)
+				continue
+			}
+			defer func() {
+				_ = conn.Close()
+			}()
+			partitions, err := conn.ReadPartitions()
+			if err != nil {
+				lib.logf(ctx, "[events] could not list partitions on broker %s: %v", broker, err)
 				continue
 			}
 			lib.logf(ctx, "[events] listing existing topics...")

--- a/topics.go
+++ b/topics.go
@@ -110,7 +110,9 @@ func (lib *LibraryNoDB) precreateTopicsForConsuming(ctx context.Context, consume
 func (lib *LibraryNoDB) configureTopicsPrework() {
 	lib.topicsWork.MaxSimultaneous = 20
 	lib.topicsWork.BackoffPolicy = backoffPolicy
-	lib.topicsWork.ThreadContext = lib.threadContext
+	lib.topicsWork.ThreadContext = func(_ context.Context, spanMap map[string]string) (context.Context, func()) {
+		return lib.threadContext(spanMap)
+	}
 	lib.topicsWork.WorkDeadline = topicCreationDeadline
 	lib.topicsWork.ItemRetryDelay = 5 * time.Second
 	lib.topicsWork.ErrorReporter = func(ctx context.Context, err error, why topicsWhy) {
@@ -300,7 +302,7 @@ func (lib *LibraryNoDB) waitForTopicsListing(ctx context.Context) error {
 	lib.topicListingStarted.Do(func() {
 		// The listing thread is library-owned. Individual callers may stop waiting
 		// via ctx, but must not cancel the one shared listing attempt.
-		threadCtx, threadDone := lib.threadContext(context.Background(), map[string]string{
+		threadCtx, threadDone := lib.threadContext(map[string]string{
 			"action": "thread",
 			"thread": "list available topics",
 		})

--- a/topics.go
+++ b/topics.go
@@ -110,9 +110,7 @@ func (lib *LibraryNoDB) precreateTopicsForConsuming(ctx context.Context, consume
 func (lib *LibraryNoDB) configureTopicsPrework() {
 	lib.topicsWork.MaxSimultaneous = 20
 	lib.topicsWork.BackoffPolicy = backoffPolicy
-	lib.topicsWork.ThreadContext = func(_ context.Context, spanMap map[string]string) (context.Context, func()) {
-		return lib.threadContext(spanMap)
-	}
+	lib.topicsWork.ThreadContext = lib.threadContext
 	lib.topicsWork.WorkDeadline = topicCreationDeadline
 	lib.topicsWork.ItemRetryDelay = 5 * time.Second
 	lib.topicsWork.ErrorReporter = func(ctx context.Context, err error, why topicsWhy) {
@@ -302,7 +300,7 @@ func (lib *LibraryNoDB) waitForTopicsListing(ctx context.Context) error {
 	lib.topicListingStarted.Do(func() {
 		// The listing thread is library-owned. Individual callers may stop waiting
 		// via ctx, but must not cancel the one shared listing attempt.
-		threadCtx, threadDone := lib.threadContext(map[string]string{
+		threadCtx, threadDone := lib.threadContext(lib.shutdownCtx, map[string]string{
 			"action": "thread",
 			"thread": "list available topics",
 		})

--- a/topics_test.go
+++ b/topics_test.go
@@ -1,0 +1,57 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/singlestore-labs/events/eventmodels"
+)
+
+func TestTopicListingRetryWaitsAndCanRetryAfterContextCancel(t *testing.T) {
+	var lock sync.Mutex
+	var logs []string
+	tracer := func(context.Context) eventmodels.Tracer {
+		return func(format string, a ...any) {
+			lock.Lock()
+			defer lock.Unlock()
+			logs = append(logs, fmt.Sprintf(format, a...))
+		}
+	}
+
+	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
+	lib.Configure(nil, tracer, false, nil, nil, []string{"${NODE_IP}:30992"})
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		err := lib.waitForTopicsListing(ctx)
+		cancel()
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+		lock.Lock()
+		starts := countLogsContaining(logs, "starting over on listing topics")
+		lock.Unlock()
+		assert.Equal(t, attempt, starts)
+	}
+
+	select {
+	case <-lib.topicsHaveBeenListed:
+		t.Fatal("topics should not be marked listed after failed listing attempts")
+	default:
+	}
+}
+
+func countLogsContaining(logs []string, needle string) int {
+	var count int
+	for _, line := range logs {
+		if strings.Contains(line, needle) {
+			count++
+		}
+	}
+	return count
+}

--- a/topics_test.go
+++ b/topics_test.go
@@ -2,56 +2,40 @@ package events
 
 import (
 	"context"
-	"fmt"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
+	"github.com/lestrrat-go/backoff/v2"
+	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/singlestore-labs/events/eventmodels"
 )
 
-func TestTopicListingRetryWaitsAndCanRetryAfterContextCancel(t *testing.T) {
-	var lock sync.Mutex
-	var logs []string
-	tracer := func(context.Context) eventmodels.Tracer {
-		return func(format string, a ...any) {
-			lock.Lock()
-			defer lock.Unlock()
-			logs = append(logs, fmt.Sprintf(format, a...))
-		}
-	}
+func TestTopicListingRetryWaitsBeforeTryingAgain(t *testing.T) {
+	origBackoffPolicy := topicListingBackoffPolicy
+	topicListingBackoffPolicy = backoff.Exponential(
+		backoff.WithMinInterval(50*time.Millisecond),
+		backoff.WithMaxInterval(50*time.Millisecond),
+		backoff.WithJitterFactor(0),
+		backoff.WithMaxRetries(0),
+	)
+	defer func() {
+		topicListingBackoffPolicy = origBackoffPolicy
+	}()
 
 	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
-	lib.Configure(nil, tracer, false, nil, nil, []string{"${NODE_IP}:30992"})
+	lib.Configure(nil, nil, false, nil, nil, []string{"${NODE_IP}:30992"})
 
-	for attempt := 1; attempt <= 2; attempt++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-		err := lib.waitForTopicsListing(ctx)
-		cancel()
-		assert.ErrorIs(t, err, context.DeadlineExceeded)
-
-		lock.Lock()
-		starts := countLogsContaining(logs, "starting over on listing topics")
-		lock.Unlock()
-		assert.Equal(t, attempt, starts)
-	}
-
-	select {
-	case <-lib.topicsHaveBeenListed:
-		t.Fatal("topics should not be marked listed after failed listing attempts")
-	default:
-	}
-}
-
-func countLogsContaining(logs []string, needle string) int {
-	var count int
-	for _, line := range logs {
-		if strings.Contains(line, needle) {
-			count++
+	var attempts []time.Time
+	lib.listAvailableTopicsWith(context.Background(), func(context.Context, string) ([]kafka.Partition, bool) {
+		attempts = append(attempts, time.Now())
+		if len(attempts) == 1 {
+			return nil, false
 		}
-	}
-	return count
+		return []kafka.Partition{{Topic: "existing-topic"}}, true
+	})
+
+	assert.Len(t, attempts, 2)
+	assert.GreaterOrEqual(t, attempts[1].Sub(attempts[0]), 45*time.Millisecond)
 }

--- a/topics_test.go
+++ b/topics_test.go
@@ -8,18 +8,20 @@ import (
 	"github.com/lestrrat-go/backoff/v2"
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/singlestore-labs/events/eventmodels"
 )
 
-func TestTopicListingRetryWaitsBeforeTryingAgain(t *testing.T) {
+func TestTopicListingRetryWaitsForBackoffBeforeTryingAgain(t *testing.T) {
+	controller := &testTopicListingBackoffController{
+		done: make(chan struct{}),
+		next: make(chan struct{}, 1),
+	}
+	controller.next <- struct{}{}
+
 	origBackoffPolicy := topicListingBackoffPolicy
-	topicListingBackoffPolicy = backoff.Exponential(
-		backoff.WithMinInterval(50*time.Millisecond),
-		backoff.WithMaxInterval(50*time.Millisecond),
-		backoff.WithJitterFactor(0),
-		backoff.WithMaxRetries(0),
-	)
+	topicListingBackoffPolicy = testTopicListingBackoffPolicy{controller: controller}
 	defer func() {
 		topicListingBackoffPolicy = origBackoffPolicy
 	}()
@@ -27,15 +29,65 @@ func TestTopicListingRetryWaitsBeforeTryingAgain(t *testing.T) {
 	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
 	lib.Configure(nil, nil, false, nil, nil, []string{"${NODE_IP}:30992"})
 
-	var attempts []time.Time
-	lib.listAvailableTopicsWith(context.Background(), func(context.Context, string) ([]kafka.Partition, bool) {
-		attempts = append(attempts, time.Now())
-		if len(attempts) == 1 {
-			return nil, false
-		}
-		return []kafka.Partition{{Topic: "existing-topic"}}, true
-	})
+	attempts := make(chan int, 2)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var attempt int
+		lib.listAvailableTopicsWith(context.Background(), func(context.Context, string) ([]kafka.Partition, bool) {
+			attempt++
+			attempts <- attempt
+			if attempt == 1 {
+				return nil, false
+			}
+			return []kafka.Partition{{Topic: "existing-topic"}}, true
+		})
+	}()
 
-	assert.Len(t, attempts, 2)
-	assert.GreaterOrEqual(t, attempts[1].Sub(attempts[0]), 45*time.Millisecond)
+	require.Equal(t, 1, requireTopicListingAttempt(t, attempts))
+	select {
+	case attempt := <-attempts:
+		t.Fatalf("unexpected listing attempt before backoff allowed it: %d", attempt)
+	default:
+	}
+
+	controller.next <- struct{}{}
+	assert.Equal(t, 2, requireTopicListingAttempt(t, attempts))
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for topic listing to finish")
+	}
+}
+
+type testTopicListingBackoffPolicy struct {
+	controller backoff.Controller
+}
+
+func (p testTopicListingBackoffPolicy) Start(context.Context) backoff.Controller {
+	return p.controller
+}
+
+type testTopicListingBackoffController struct {
+	done chan struct{}
+	next chan struct{}
+}
+
+func (c *testTopicListingBackoffController) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *testTopicListingBackoffController) Next() <-chan struct{} {
+	return c.next
+}
+
+func requireTopicListingAttempt(t *testing.T, attempts <-chan int) int {
+	t.Helper()
+	select {
+	case attempt := <-attempts:
+		return attempt
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for topic listing attempt")
+		return 0
+	}
 }

--- a/topics_test.go
+++ b/topics_test.go
@@ -20,7 +20,7 @@ func TestTopicListingRetryWaitsForBackoffBeforeTryingAgain(t *testing.T) {
 	controller.next <- struct{}{}
 
 	origBackoffPolicy := topicListingBackoffPolicy
-	topicListingBackoffPolicy = testTopicListingBackoffPolicy{controller: controller}
+	topicListingBackoffPolicy = newTestTopicListingBackoffPolicy(controller)
 	defer func() {
 		topicListingBackoffPolicy = origBackoffPolicy
 	}()
@@ -60,12 +60,72 @@ func TestTopicListingRetryWaitsForBackoffBeforeTryingAgain(t *testing.T) {
 	}
 }
 
+func TestTopicListingCanRetryAfterFailedAttempt(t *testing.T) {
+	firstController := &testTopicListingBackoffController{
+		done: make(chan struct{}),
+		next: make(chan struct{}, 1),
+	}
+	firstController.next <- struct{}{}
+	secondController := &testTopicListingBackoffController{
+		done: make(chan struct{}),
+		next: make(chan struct{}, 1),
+	}
+	secondController.next <- struct{}{}
+
+	origBackoffPolicy := topicListingBackoffPolicy
+	topicListingBackoffPolicy = newTestTopicListingBackoffPolicy(firstController, secondController)
+	defer func() {
+		topicListingBackoffPolicy = origBackoffPolicy
+	}()
+
+	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
+	logs := make(chan string, 40)
+	tracer := func(context.Context) eventmodels.Tracer {
+		return func(format string, a ...any) {
+			logs <- fmt.Sprintf(format, a...)
+		}
+	}
+	lib.Configure(nil, tracer, false, nil, nil, []string{"$$$invalid hostname$$$:1"})
+
+	firstErr := make(chan error, 1)
+	go func() {
+		firstErr <- lib.waitForTopicsListing(context.Background())
+	}()
+	requireTopicListingLog(t, logs, "waiting before making another attempt to list topics")
+	close(firstController.done)
+	requireTopicListingError(t, firstErr)
+
+	select {
+	case <-lib.topicsHaveBeenListed:
+		t.Fatal("topics should not be marked listed after a failed listing attempt")
+	default:
+	}
+
+	secondErr := make(chan error, 1)
+	go func() {
+		secondErr <- lib.waitForTopicsListing(context.Background())
+	}()
+	requireTopicListingLog(t, logs, "starting over on listing topics")
+	close(secondController.done)
+	requireTopicListingError(t, secondErr)
+}
+
 type testTopicListingBackoffPolicy struct {
-	controller backoff.Controller
+	controllers chan backoff.Controller
+}
+
+func newTestTopicListingBackoffPolicy(controllers ...backoff.Controller) testTopicListingBackoffPolicy {
+	ch := make(chan backoff.Controller, len(controllers))
+	for _, controller := range controllers {
+		ch <- controller
+	}
+	return testTopicListingBackoffPolicy{
+		controllers: ch,
+	}
 }
 
 func (p testTopicListingBackoffPolicy) Start(context.Context) backoff.Controller {
-	return p.controller
+	return <-p.controllers
 }
 
 type testTopicListingBackoffController struct {
@@ -94,5 +154,17 @@ func requireTopicListingLog(t *testing.T, logs <-chan string, contains string) s
 			t.Fatalf("timed out waiting for log containing %q", contains)
 			return ""
 		}
+	}
+}
+
+func requireTopicListingError(t *testing.T, errCh <-chan error) {
+	t.Helper()
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected topic listing error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for topic listing error")
 	}
 }

--- a/topics_test.go
+++ b/topics_test.go
@@ -34,10 +34,9 @@ func TestTopicListingRetryWaitsForBackoffBeforeTryingAgain(t *testing.T) {
 	}
 	lib.Configure(nil, tracer, false, nil, nil, []string{"$$$invalid hostname$$$:1"})
 
-	done := make(chan struct{})
+	errCh := make(chan error, 1)
 	go func() {
-		defer close(done)
-		lib.listAvailableTopics(context.Background())
+		errCh <- lib.listAvailableTopics(context.Background())
 	}()
 
 	requireTopicListingLog(t, logs, "starting over on listing topics")
@@ -52,7 +51,10 @@ func TestTopicListingRetryWaitsForBackoffBeforeTryingAgain(t *testing.T) {
 
 	close(controller.done)
 	select {
-	case <-done:
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected topic listing to fail when backoff stops before success")
+		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for topic listing to finish")
 	}

--- a/topics_test.go
+++ b/topics_test.go
@@ -60,20 +60,15 @@ func TestTopicListingRetryWaitsForBackoffBeforeTryingAgain(t *testing.T) {
 	}
 }
 
-func TestTopicListingCanRetryAfterFailedAttempt(t *testing.T) {
+func TestTopicListingContinuesAfterCallerCancel(t *testing.T) {
 	firstController := &testTopicListingBackoffController{
 		done: make(chan struct{}),
 		next: make(chan struct{}, 1),
 	}
 	firstController.next <- struct{}{}
-	secondController := &testTopicListingBackoffController{
-		done: make(chan struct{}),
-		next: make(chan struct{}, 1),
-	}
-	secondController.next <- struct{}{}
 
 	origBackoffPolicy := topicListingBackoffPolicy
-	topicListingBackoffPolicy = newTestTopicListingBackoffPolicy(firstController, secondController)
+	topicListingBackoffPolicy = newTestTopicListingBackoffPolicy(firstController)
 	defer func() {
 		topicListingBackoffPolicy = origBackoffPolicy
 	}()
@@ -87,27 +82,24 @@ func TestTopicListingCanRetryAfterFailedAttempt(t *testing.T) {
 	}
 	lib.Configure(nil, tracer, false, nil, nil, []string{"$$$invalid hostname$$$:1"})
 
+	ctx, cancel := context.WithCancel(context.Background())
 	firstErr := make(chan error, 1)
 	go func() {
-		firstErr <- lib.waitForTopicsListing(context.Background())
+		firstErr <- lib.waitForTopicsListing(ctx)
 	}()
 	requireTopicListingLog(t, logs, "waiting before making another attempt to list topics")
-	close(firstController.done)
+	cancel()
 	requireTopicListingError(t, firstErr)
 
 	select {
 	case <-lib.topicsHaveBeenListed:
-		t.Fatal("topics should not be marked listed after a failed listing attempt")
+		t.Fatal("topics should not be marked listed when listing is still running")
 	default:
 	}
 
-	secondErr := make(chan error, 1)
-	go func() {
-		secondErr <- lib.waitForTopicsListing(context.Background())
-	}()
+	firstController.next <- struct{}{}
 	requireTopicListingLog(t, logs, "starting over on listing topics")
-	close(secondController.done)
-	requireTopicListingError(t, secondErr)
+	close(firstController.done)
 }
 
 type testTopicListingBackoffPolicy struct {

--- a/topics_test.go
+++ b/topics_test.go
@@ -116,8 +116,8 @@ func newTestTopicListingBackoffPolicy(controllers ...backoff.Controller) testTop
 	}
 }
 
-func (p testTopicListingBackoffPolicy) Start(context.Context) backoff.Controller {
-	return <-p.controllers
+func (p testTopicListingBackoffPolicy) Start(ctx context.Context) backoff.Controller {
+	return newTestTopicListingBackoffControllerWithContext(ctx, <-p.controllers)
 }
 
 type testTopicListingBackoffController struct {
@@ -131,6 +131,34 @@ func (c *testTopicListingBackoffController) Done() <-chan struct{} {
 
 func (c *testTopicListingBackoffController) Next() <-chan struct{} {
 	return c.next
+}
+
+type testTopicListingBackoffControllerWithContext struct {
+	controller backoff.Controller
+	done       chan struct{}
+}
+
+func newTestTopicListingBackoffControllerWithContext(ctx context.Context, controller backoff.Controller) testTopicListingBackoffControllerWithContext {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		select {
+		case <-ctx.Done():
+		case <-controller.Done():
+		}
+	}()
+	return testTopicListingBackoffControllerWithContext{
+		controller: controller,
+		done:       done,
+	}
+}
+
+func (c testTopicListingBackoffControllerWithContext) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c testTopicListingBackoffControllerWithContext) Next() <-chan struct{} {
+	return c.controller.Next()
 }
 
 func requireTopicListingLog(t *testing.T, logs <-chan string, contains string) string {

--- a/topics_test.go
+++ b/topics_test.go
@@ -32,7 +32,7 @@ func TestTopicListingRetryWaitsForBackoffBeforeTryingAgain(t *testing.T) {
 			logs <- fmt.Sprintf(format, a...)
 		}
 	}
-	lib.Configure(nil, tracer, false, nil, nil, []string{"$$$invalid hostname$$$:1"})
+	lib.Configure(nil, tracer, false, nil, nil, nil)
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -80,7 +80,7 @@ func TestTopicListingContinuesAfterCallerCancel(t *testing.T) {
 			logs <- fmt.Sprintf(format, a...)
 		}
 	}
-	lib.Configure(nil, tracer, false, nil, nil, []string{"$$$invalid hostname$$$:1"})
+	lib.Configure(nil, tracer, false, nil, nil, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	firstErr := make(chan error, 1)

--- a/topics_test.go
+++ b/topics_test.go
@@ -32,7 +32,7 @@ func TestTopicListingRetryWaitsForBackoffBeforeTryingAgain(t *testing.T) {
 			logs <- fmt.Sprintf(format, a...)
 		}
 	}
-	lib.Configure(nil, tracer, false, nil, nil, []string{"${NODE_IP}:30992"})
+	lib.Configure(nil, tracer, false, nil, nil, []string{"$$$invalid hostname$$$:1"})
 
 	done := make(chan struct{})
 	go func() {

--- a/topics_test.go
+++ b/topics_test.go
@@ -2,13 +2,12 @@ package events
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/lestrrat-go/backoff/v2"
-	"github.com/segmentio/kafka-go"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/singlestore-labs/events/eventmodels"
 )
@@ -27,32 +26,31 @@ func TestTopicListingRetryWaitsForBackoffBeforeTryingAgain(t *testing.T) {
 	}()
 
 	lib := New[eventmodels.BinaryEventID, *NoDBTx, *NoDB]()
-	lib.Configure(nil, nil, false, nil, nil, []string{"${NODE_IP}:30992"})
+	logs := make(chan string, 20)
+	tracer := func(context.Context) eventmodels.Tracer {
+		return func(format string, a ...any) {
+			logs <- fmt.Sprintf(format, a...)
+		}
+	}
+	lib.Configure(nil, tracer, false, nil, nil, []string{"${NODE_IP}:30992"})
 
-	attempts := make(chan int, 2)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		var attempt int
-		lib.listAvailableTopicsWith(context.Background(), func(context.Context, string) ([]kafka.Partition, bool) {
-			attempt++
-			attempts <- attempt
-			if attempt == 1 {
-				return nil, false
-			}
-			return []kafka.Partition{{Topic: "existing-topic"}}, true
-		})
+		lib.listAvailableTopics(context.Background())
 	}()
 
-	require.Equal(t, 1, requireTopicListingAttempt(t, attempts))
+	requireTopicListingLog(t, logs, "starting over on listing topics")
+	requireTopicListingLog(t, logs, "waiting before making another attempt to list topics")
 	select {
-	case attempt := <-attempts:
-		t.Fatalf("unexpected listing attempt before backoff allowed it: %d", attempt)
+	case log := <-logs:
+		if strings.Contains(log, "starting over on listing topics") {
+			t.Fatalf("unexpected listing attempt before backoff allowed it: %s", log)
+		}
 	default:
 	}
 
-	controller.next <- struct{}{}
-	assert.Equal(t, 2, requireTopicListingAttempt(t, attempts))
+	close(controller.done)
 	select {
 	case <-done:
 	case <-time.After(time.Second):
@@ -81,13 +79,18 @@ func (c *testTopicListingBackoffController) Next() <-chan struct{} {
 	return c.next
 }
 
-func requireTopicListingAttempt(t *testing.T, attempts <-chan int) int {
+func requireTopicListingLog(t *testing.T, logs <-chan string, contains string) string {
 	t.Helper()
-	select {
-	case attempt := <-attempts:
-		return attempt
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for topic listing attempt")
-		return 0
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case log := <-logs:
+			if strings.Contains(log, contains) {
+				return log
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for log containing %q", contains)
+			return ""
+		}
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a dedicated exponential backoff policy for Kafka topic listing retries, with infinite retries to preserve the old listing loop behavior
- Gate the separate infinite-retry change for existing shared backoff policies with `EventsExistingBackoffInfiniteRetries`, so setting `DISABLE_CODE_EventsExistingBackoffInfiniteRetries` falls back to the backoff package's default retry cap for those existing loops
- Preserve the existing `sync.Once` topic-listing lifecycle and run the listing loop under `threadContext`, so request-scoped cancellation does not stop library-owned listing work
- Gate dynamic `threadContext` lifecycle handling with `EventsThreadContextLifecycle`; disabling it falls back to `threadContextOld`, which preserves the prior implementation
- Inline the gated `threadContext` behavior so eventual gate removal is line-only: remove the gate, the disabled fallback block, `threadContextOld`, and the temporary `backupCtx` parameter
- Teach the gated `threadContext` path to observe consume/catch-up-produce contexts registered after the thread starts by broadcasting lifecycle context updates
- Keep the gated `threadContext` path alive until `Shutdown` when no consume/catch-up-produce lifecycle is ever registered; restored the context parameter on the direct `threadContext` API for rollback compatibility
- Track both the gated `threadContext` lifecycle goroutine and returned callback in `libraryDone`, so callers must invoke the callback before shutdown is complete
- Make `Shutdown` harmless to call more than once, and document when lifecycle context update notifications should be emitted
- Clarify `Shutdown` docs: cancel consume/catch-up contexts before calling it; if those lifecycles were never started, call it to terminate background threads
- Clean up `Shutdown` lock/defer ordering
- Close topic-listing broker connections immediately after partition reads and return the listing result to waiters if the listing goroutine exits
- Add focused regression tests that capture topic-listing logs and verify retries wait for backoff and listing continues after caller cancellation without network dialing
- Increase the broadcast batch delivery test timeout and lengthen its heartbeat interval so heartbeat traffic does not mask reader idle recovery while waiting for application-topic delivery

## Testing
- `go test ./... -run 'Test(ThreadContext(AdoptsLateLifecycleContext|WithoutLifecycleLastsUntilShutdown)|ShutdownCanBeCalledTwice)|TestTopicListing(RetryWaitsForBackoffBeforeTryingAgain|ContinuesAfterCallerCancel)' -count=1`
- `go test ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-740cf591-9a53-49c6-9573-bb388d0db70d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-740cf591-9a53-49c6-9573-bb388d0db70d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

